### PR TITLE
Add July 2026 Windows client identity offsets

### DIFF
--- a/configs/addons/BotHider/gamedata.json
+++ b/configs/addons/BotHider/gamedata.json
@@ -79,6 +79,12 @@
     },
     "comment": "network channel pointer"
   },
+  "CServerSideClient::m_nConnectionTypeFlags": {
+    "offsets": {
+      "windows": 96
+    },
+    "comment": "Windows connection-type byte; zero or bit 0x08 denotes a fake connection"
+  },
   "CServerSideClient::m_nSignonState": {
     "offsets": {
       "windows": 100,
@@ -113,6 +119,12 @@
       "linux": 171
     },
     "comment": "steam id"
+  },
+  "CServerSideClient::m_SteamIDMirror": {
+    "offsets": {
+      "windows": 179
+    },
+    "comment": "second Windows identity field written alongside m_SteamID by current engine2 auth/connect paths"
   },
   "CServerSideClient::m_bIsHLTV": {
     "offsets": {


### PR DESCRIPTION
## Summary

- Record the Windows `CServerSideClient` connection-type byte at `+0x60`.
- Record the second Windows SteamID identity field at `+0xB3`, alongside the existing `+0xAB` field.

These are gamedata observations only. This PR intentionally does not change runtime logic, hooks, vtables, or Linux data. `m_SteamIDMirror` is a descriptive plugin key, not a claimed Valve schema field name.

## Evidence

- Observed on the Windows CS2 `1.41.6.9/14169` (`10847`) build after the July 9, 2026 update.
- The connection-type byte uses `0x08` for a fake connection and `0x01` for a human connection.
- Current engine2 auth/connect paths write the same SteamID value at offsets `+0xAB` and `+0xB3`.

## Validation

- Parsed `gamedata.json` successfully.
- `git diff --check` passes.
