### PR TITLE
feat: add self-contained managed bot POV HUD controls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ add_library(BotHider SHARED
     src/slot_publisher.cpp
     src/sig_scan.cpp
     src/schema_resolver.cpp
+    src/hud_pov_presentation.cpp
     ${PROTO_SRCS}
     ${SDK_SOURCES}
 )

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ When a bot joins, BotHider automatically:
 | `bh_setflair <slot> <item_def_index>` | Change a bot's scoreboard flair (`0` clears it) |
 | `bh_disguise <0/1>` | Turn bot disguise off (0) or on (1) |
 | `bh_namesource <0/1>` | **0** = use name from `botprofile.db` (default)<br>**1** = use name from `bot_info.json` (only affects new bots) |
+| `bh_ob_pov <true/false>` | Show the normal POV HUD instead of the spectator card while watching a managed bot in-eye |
+
+Observer POV presentation defaults to `true`. BotHider always hides the vanilla
+bot-takeover notice while a managed bot is being controlled, because the rest of
+the normal POV HUD is unchanged. BotHider's Windows native runtime applies the
+local `client.dll`/Panorama presentation directly; dedicated servers skip the
+client-only hook and remote clients are unaffected.
 
 ------------------------------------------------------------------------
 

--- a/configs/addons/BotHider/gamedata.json
+++ b/configs/addons/BotHider/gamedata.json
@@ -1,4 +1,28 @@
 {
+  "CS2Hud::UpdateBotTakeoverHint": {
+    "signatures": {
+      "library": "client",
+      "windows": "48 89 5C 24 18 48 89 6C 24 20 57 48 81 EC 50 01 00 00 65 48 8B 04 25 58 00 00 00 48 8B F9",
+      "linux": ""
+    },
+    "comment": "Updates JoinPanelParent/JoinTextBot with #SFUI_Notice_Hint_Bot_Takeover. Windows signature and panel layout verified against client.dll 2026-07-10."
+  },
+  "CSGOHudHealthAmmoCenter::UpdateSpecPlayer": {
+    "signatures": {
+      "library": "client",
+      "windows": "40 53 56 57 41 54 41 55 41 56 41 57 48 83 EC 30 4C 8B F9 48 8D 4C 24 70 E8 ?? ?? ?? ?? 8B 54 24 70",
+      "linux": ""
+    },
+    "comment": "Updates the spectator player card, avatar/legend, and key hints in CSGOHudHealthAmmoCenter. Windows signature and Panorama handle layout verified against client.dll 2026-07-10."
+  },
+  "Panorama::MakeSymbol": {
+    "signatures": {
+      "library": "client",
+      "windows": "48 89 5C 24 08 57 48 83 EC 20 48 8B F9 48 8B DA 48 8B 0D ?? ?? ?? ?? 48 85 C9 75 1C FF 15 ?? ?? ?? ?? 85 C0 74 01 CC 48 8B D3 48 8D 0D ?? ?? ?? ?? FF 15 ?? ?? ?? ?? CC 48 8B 01 4C 8B C3 33 D2 FF 90 88 03 00 00",
+      "linux": ""
+    },
+    "comment": "Creates the 16-bit Panorama symbol used by IUIPanel::SetHasClass. Windows signature verified against client.dll 2026-07-10."
+  },
   "UTIL_Remove": {
     "signatures": {
       "library": "server",

--- a/csharp/BotHiderImpl/BotHiderImplPlugin.cs
+++ b/csharp/BotHiderImpl/BotHiderImplPlugin.cs
@@ -48,6 +48,7 @@ public class BotHiderImplPlugin : BasePlugin
         _harmony.PatchAll(typeof(BotHiderImplPlugin).Assembly);
 
         AddTimer(2.0f, ApplyManagedSlots, TimerFlags.REPEAT);
+        RegisterListener<Listeners.OnTick>(UpdatePovMasks);
         StartFastApplyWindow();
     }
 
@@ -60,6 +61,7 @@ public class BotHiderImplPlugin : BasePlugin
         _api = null;
         _fastApplyTimer?.Kill();
         _fastApplyTimer = null;
+        _client?.PublishPovMasks(0, 0);
         _client?.Dispose();
     }
 
@@ -259,6 +261,96 @@ public class BotHiderImplPlugin : BasePlugin
         }
     }
 
+    private void UpdatePovMasks()
+    {
+        if (_client == null || !_client.IsConnected()) return;
+
+        var managedPawnSlots = new Dictionary<uint, int>();
+        foreach (int slot in _client.GetManagedSlots())
+        {
+            var managed = Utilities.GetPlayerFromSlot(slot);
+            if (managed?.PlayerPawn is { IsValid: true, Value.IsValid: true } pawn)
+                managedPawnSlots[pawn.Value.Index] = slot;
+        }
+
+        ulong observerMask = 0;
+        ulong takeMask = 0;
+        if (managedPawnSlots.Count != 0)
+        {
+            foreach (var controller in Utilities.GetPlayers())
+            {
+                if (controller is not { IsValid: true } ||
+                    _client.IsManagedBot(controller.Slot) || controller.IsBot)
+                    continue;
+
+                if (TryGetInEyeObserverTargetIndex(controller, out uint targetIndex) &&
+                    managedPawnSlots.TryGetValue(targetIndex, out int observedSlot))
+                    observerMask |= 1UL << observedSlot;
+
+                if (!TryGetControllingBotState(controller, out bool controllingBot) ||
+                    !controllingBot)
+                    continue;
+
+                if (controller.PlayerPawn is { IsValid: true, Value.IsValid: true } controlledPawn &&
+                    managedPawnSlots.TryGetValue(controlledPawn.Value.Index, out int controlledSlot))
+                {
+                    takeMask |= 1UL << controlledSlot;
+                    continue;
+                }
+
+                if (controller.OriginalControllerOfCurrentPawn is
+                    { IsValid: true, Value.IsValid: true } original &&
+                    _client.IsManagedBot(original.Value.Slot))
+                    takeMask |= 1UL << original.Value.Slot;
+            }
+        }
+
+        _client.PublishPovMasks(observerMask, takeMask);
+    }
+
+    private static bool TryGetInEyeObserverTargetIndex(
+        CCSPlayerController controller,
+        out uint targetIndex)
+    {
+        targetIndex = 0;
+        try
+        {
+            CPlayer_ObserverServices? observerServices = null;
+            if (controller.ObserverPawn is { IsValid: true, Value.IsValid: true } observerPawn)
+                observerServices = observerPawn.Value.ObserverServices;
+            else if (controller.PlayerPawn is { IsValid: true, Value.IsValid: true } playerPawn)
+                observerServices = playerPawn.Value.ObserverServices;
+
+            if (observerServices == null ||
+                observerServices.ObserverMode != (byte)ObserverMode_t.OBS_MODE_IN_EYE ||
+                observerServices.ObserverTarget is not { IsValid: true, Value.IsValid: true } target)
+                return false;
+
+            targetIndex = target.Value.Index;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool TryGetControllingBotState(
+        CCSPlayerController controller,
+        out bool controllingBot)
+    {
+        controllingBot = false;
+        try
+        {
+            controllingBot = controller.ControllingBot;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     // Apply the scoreboard flair rank span for one player
     private static bool TryApplyScoreboardFlair(int slot, uint itemDefIndex)
     {
@@ -392,6 +484,41 @@ public class BotHiderImplPlugin : BasePlugin
         bool useBotInfo = v != 0;
         bool ok = _client.SetNameSource(useBotInfo);
         cmd.ReplyToCommand($"[BotHider] name source -> {(useBotInfo ? "bot_info" : "botprofile")} ({ok})");
+    }
+
+    [ConsoleCommand("bh_ob_pov", "POV-style HUD while observing managed bots: bh_ob_pov <true|false>")]
+    public void OnObserverPov(CCSPlayerController? player, CommandInfo cmd)
+    {
+        if (_client == null) { cmd.ReplyToCommand("[BotHider] not initialized"); return; }
+        if (cmd.ArgCount < 2)
+        {
+            cmd.ReplyToCommand($"[BotHider] observer POV -> {_client.ObserverPovEnabled.ToString().ToLowerInvariant()}");
+            return;
+        }
+        if (!TryParseToggle(cmd.GetArg(1), out bool enabled))
+        { cmd.ReplyToCommand("usage: bh_ob_pov <true|false>"); return; }
+        bool ok = _client.SetObserverPovEnabled(enabled);
+        cmd.ReplyToCommand($"[BotHider] observer POV -> {enabled.ToString().ToLowerInvariant()} ({ok})");
+    }
+
+    private static bool TryParseToggle(string value, out bool enabled)
+    {
+        switch (value.Trim().ToLowerInvariant())
+        {
+            case "true":
+            case "1":
+            case "on":
+                enabled = true;
+                return true;
+            case "false":
+            case "0":
+            case "off":
+                enabled = false;
+                return true;
+            default:
+                enabled = false;
+                return false;
+        }
     }
 }
 

--- a/csharp/BotHiderImpl/SharedMemoryClient.cs
+++ b/csharp/BotHiderImpl/SharedMemoryClient.cs
@@ -35,6 +35,12 @@ public sealed class SharedMemoryClient : IBotHiderApi, IDisposable
     private const int MaxSigs = 8;
     // Scoreboard flair region
     private const int OffScoreboardFlair = 10400;  // uint32[64]
+    // Client HUD POV state region consumed by BotHider native
+    private const int OffObserverPovMask = 10656;  // uint64 managed-slot mask
+    private const int OffTakePovMask = 10664;      // uint64 managed-slot mask
+    private const int OffObserverPovEnabled = 10672; // byte bool
+    private const int OffPovInitialized = 10674;     // byte marker
+    private const byte PovInitializedMarker = 0xA5;
 
     // Command region offsets
     private const int OffWriteIdx = 2640;
@@ -87,6 +93,7 @@ public sealed class SharedMemoryClient : IBotHiderApi, IDisposable
             _view = _mmf.CreateViewAccessor(0, TotalSize,
                 MemoryMappedFileAccess.ReadWrite);
             if (_view.ReadUInt32(OffMagic) != Magic) { Dispose(); return false; }
+            InitializePovState();
             return true;
         }
         catch (FileNotFoundException) { return false; }
@@ -104,6 +111,33 @@ public sealed class SharedMemoryClient : IBotHiderApi, IDisposable
     {
         if (_view != null) return true;
         return TryConnect();
+    }
+
+    private void InitializePovState()
+    {
+        if (_view == null || _view.ReadByte(OffPovInitialized) == PovInitializedMarker)
+            return;
+        _view.Write(OffObserverPovMask, 0UL);
+        _view.Write(OffTakePovMask, 0UL);
+        _view.Write(OffObserverPovEnabled, (byte)1);
+        _view.Write(OffPovInitialized, PovInitializedMarker);
+    }
+
+    public bool ObserverPovEnabled =>
+        IsConnected() && _view!.ReadByte(OffObserverPovEnabled) != 0;
+
+    public bool SetObserverPovEnabled(bool enabled)
+    {
+        if (!IsConnected()) return false;
+        _view!.Write(OffObserverPovEnabled, enabled ? (byte)1 : (byte)0);
+        return true;
+    }
+
+    public void PublishPovMasks(ulong observerMask, ulong takeMask)
+    {
+        if (!IsConnected()) return;
+        _view!.Write(OffObserverPovMask, observerMask);
+        _view.Write(OffTakePovMask, takeMask);
     }
 
     // IBotHiderApi: read side

--- a/src/hud_pov_presentation.cpp
+++ b/src/hud_pov_presentation.cpp
@@ -1,0 +1,296 @@
+#include "hud_pov_presentation.h"
+
+#include "inline_hook.h"
+#include "sig_scan.h"
+#include "slot_publisher.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#if defined(_WIN32)
+#include <Windows.h>
+#define BH_FASTCALL __fastcall
+#else
+#define BH_FASTCALL
+#endif
+
+namespace cs2bh::HudPovPresentation
+{
+    namespace
+    {
+        constexpr const char *kTakeoverUpdateSigName = "CS2Hud::UpdateBotTakeoverHint";
+        constexpr const char *kSpecUpdateSigName = "CSGOHudHealthAmmoCenter::UpdateSpecPlayer";
+        constexpr const char *kMakeSymbolSigName = "Panorama::MakeSymbol";
+
+        constexpr unsigned char kTakeoverUpdatePrologue[] = {
+            0x48, 0x89, 0x5C, 0x24, 0x18, 0x48, 0x89, 0x6C,
+            0x24, 0x20, 0x57, 0x48, 0x81, 0xEC, 0x50, 0x01,
+            0x00, 0x00};
+        constexpr unsigned char kSpecUpdatePrologue[] = {
+            0x40, 0x53, 0x56, 0x57, 0x41, 0x54, 0x41, 0x55,
+            0x41, 0x56, 0x41, 0x57, 0x48, 0x83, 0xEC, 0x30};
+        constexpr unsigned char kMakeSymbolPrologue[] = {
+            0x48, 0x89, 0x5C, 0x24, 0x08, 0x57, 0x48, 0x83,
+            0xEC, 0x20, 0x48, 0x8B, 0xF9, 0x48, 0x8B, 0xDA};
+
+        // The stolen prologues contain only position-independent instructions.
+        constexpr size_t kTakeoverStealLen = sizeof(kTakeoverUpdatePrologue);
+        constexpr size_t kSpecStealLen = sizeof(kSpecUpdatePrologue);
+
+        // Recovered from client.dll and hudhealthammocenter.vxml/vcss on
+        // 2026-07-10. JoinTextBot is independent from the native team emblem.
+        constexpr size_t kJoinTextBotOffset = 0xC0;
+        constexpr size_t kPanelInterfaceOffset = 0x08;
+        constexpr size_t kSetVisibleVtableOffset = 0x108;
+        constexpr size_t kSetHasClassVtableOffset = 0x500;
+
+        // CCSGO_HudHealthAmmoCenter Panorama handles.
+        constexpr size_t kSpecBackgroundHandleOffset = 0x90;
+        constexpr size_t kSpecAvatarHandleOffset = 0x98;
+        constexpr size_t kSpecLegendHandleOffset = 0xA0;
+        constexpr size_t kHudRootPanelOffset = 0x08;
+
+        // UpdateSpecPlayer loads the Panorama panel registry through
+        // `mov rcx, [rip+disp32]` at +0x129 in the verified client build.
+        constexpr size_t kPanelRegistryLoadOffset = 0x129;
+        constexpr unsigned char kPanelRegistryLoadOpcode[] = {0x48, 0x8B, 0x0D};
+        constexpr size_t kResolveHandleVtableOffset = 0x110;
+        constexpr size_t kGetPanelWrapperVtableOffset = 0x40;
+
+        using UpdateFn = void(BH_FASTCALL *)(void *);
+        using SetVisibleFn = void(BH_FASTCALL *)(void *, bool);
+        using SetHasClassFn = void(BH_FASTCALL *)(void *, std::uint16_t, bool);
+        using MakeSymbolFn = void *(BH_FASTCALL *)(std::uint16_t *, const char *);
+        using ResolveHandleFn = void *(BH_FASTCALL *)(void *, const void *);
+        using GetPanelWrapperFn = void *(BH_FASTCALL *)(void *);
+
+        hook::InlineHook g_takeoverHook;
+        hook::InlineHook g_specHook;
+        UpdateFn g_takeoverOriginal = nullptr;
+        UpdateFn g_specOriginal = nullptr;
+        void **g_panelRegistryGlobal = nullptr;
+        std::uint16_t g_specVisibleClass = 0;
+        std::uint16_t g_spectatingTargetClass = 0;
+        std::string g_status = "not installed";
+
+        void SetPanelClass(void *panel, std::uint16_t symbol, bool enabled)
+        {
+            if (!panel)
+                return;
+            auto **vtable = *reinterpret_cast<void ***>(panel);
+            if (!vtable)
+                return;
+            auto setHasClass = reinterpret_cast<SetHasClassFn>(
+                vtable[kSetHasClassVtableOffset / sizeof(void *)]);
+            if (setHasClass)
+                setHasClass(panel, symbol, enabled);
+        }
+
+        void *ResolvePanelHandle(void *handle)
+        {
+            if (!handle || !g_panelRegistryGlobal || !*g_panelRegistryGlobal)
+                return nullptr;
+
+            auto *registry = *g_panelRegistryGlobal;
+            auto **registryVtable = *reinterpret_cast<void ***>(registry);
+            if (!registryVtable)
+                return nullptr;
+            auto resolve = reinterpret_cast<ResolveHandleFn>(
+                registryVtable[kResolveHandleVtableOffset / sizeof(void *)]);
+            if (!resolve)
+                return nullptr;
+
+            void *entry = resolve(registry, handle);
+            if (!entry)
+                return nullptr;
+            auto **entryVtable = *reinterpret_cast<void ***>(entry);
+            if (!entryVtable)
+                return nullptr;
+            auto getWrapper = reinterpret_cast<GetPanelWrapperFn>(
+                entryVtable[kGetPanelWrapperVtableOffset / sizeof(void *)]);
+            void *wrapper = getWrapper ? getWrapper(entry) : nullptr;
+            return wrapper ? *reinterpret_cast<void **>(
+                                 reinterpret_cast<unsigned char *>(wrapper) +
+                                 kPanelInterfaceOffset)
+                           : nullptr;
+        }
+
+        void HideTakeoverText(void *hud)
+        {
+#if defined(_WIN32)
+            __try
+            {
+                if (!hud)
+                    return;
+                auto *wrapper = *reinterpret_cast<void **>(
+                    reinterpret_cast<unsigned char *>(hud) + kJoinTextBotOffset);
+                if (!wrapper)
+                    return;
+                auto *panel = *reinterpret_cast<void **>(
+                    reinterpret_cast<unsigned char *>(wrapper) + kPanelInterfaceOffset);
+                if (!panel)
+                    return;
+                auto **vtable = *reinterpret_cast<void ***>(panel);
+                if (!vtable)
+                    return;
+                auto setVisible = reinterpret_cast<SetVisibleFn>(
+                    vtable[kSetVisibleVtableOffset / sizeof(void *)]);
+                if (setVisible)
+                    setVisible(panel, false);
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+                // A stale Panorama layout must not take down the listen server.
+            }
+#else
+            (void)hud;
+#endif
+        }
+
+        void ApplyObserverPovPresentation(void *specHud)
+        {
+#if defined(_WIN32)
+            if (!Publisher().ObserverPovActive())
+                return;
+
+            __try
+            {
+                auto *bytes = reinterpret_cast<unsigned char *>(specHud);
+                SetPanelClass(ResolvePanelHandle(bytes + kSpecBackgroundHandleOffset),
+                              g_specVisibleClass, false);
+                SetPanelClass(ResolvePanelHandle(bytes + kSpecAvatarHandleOffset),
+                              g_specVisibleClass, false);
+                SetPanelClass(ResolvePanelHandle(bytes + kSpecLegendHandleOffset),
+                              g_specVisibleClass, false);
+
+                // The native POV center remains under the spectator card.
+                // Spectating only collapses its strokes; remove that class to
+                // reveal the original T/CT emblem bar without redrawing it.
+                auto *rootPanel = *reinterpret_cast<void **>(
+                    bytes + kHudRootPanelOffset);
+                SetPanelClass(rootPanel, g_spectatingTargetClass, false);
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+                // A stale Panorama layout must not take down the listen server.
+            }
+#else
+            (void)specHud;
+#endif
+        }
+
+        void BH_FASTCALL TakeoverDetour(void *hud)
+        {
+            if (g_takeoverOriginal)
+                g_takeoverOriginal(hud);
+            if (Publisher().TakePovActive())
+                HideTakeoverText(hud);
+        }
+
+        void BH_FASTCALL SpecDetour(void *specHud)
+        {
+            if (g_specOriginal)
+                g_specOriginal(specHud);
+            ApplyObserverPovPresentation(specHud);
+        }
+    } // namespace
+
+    bool Install(const nlohmann::json &gamedata, char *errorOut, size_t errorOutLen)
+    {
+        if (g_takeoverHook.Active() && g_specHook.Active())
+            return true;
+
+#if !defined(_WIN32)
+        g_status = "unavailable: Windows client hook only";
+        return false;
+#else
+        const auto clientModule = sig::ModuleFromName("client.dll");
+        if (!clientModule)
+        {
+            g_status = "unavailable: client.dll not loaded (dedicated server)";
+            return false;
+        }
+
+        void *takeoverTarget = sig::ResolveSig(
+            gamedata, clientModule, kTakeoverUpdateSigName, errorOut, errorOutLen);
+        void *specTarget = sig::ResolveSig(
+            gamedata, clientModule, kSpecUpdateSigName, errorOut, errorOutLen);
+        void *makeSymbolTarget = sig::ResolveSig(
+            gamedata, clientModule, kMakeSymbolSigName, errorOut, errorOutLen);
+        if (!takeoverTarget || !specTarget || !makeSymbolTarget ||
+            std::memcmp(takeoverTarget, kTakeoverUpdatePrologue,
+                        sizeof(kTakeoverUpdatePrologue)) != 0 ||
+            std::memcmp(specTarget, kSpecUpdatePrologue,
+                        sizeof(kSpecUpdatePrologue)) != 0 ||
+            std::memcmp(makeSymbolTarget, kMakeSymbolPrologue,
+                        sizeof(kMakeSymbolPrologue)) != 0)
+        {
+            g_status = "unavailable: client signature/prologue mismatch";
+            return false;
+        }
+
+        auto *registryLoad = reinterpret_cast<unsigned char *>(specTarget) +
+                             kPanelRegistryLoadOffset;
+        if (std::memcmp(registryLoad, kPanelRegistryLoadOpcode,
+                        sizeof(kPanelRegistryLoadOpcode)) != 0)
+        {
+            g_status = "unavailable: Panorama registry load mismatch";
+            return false;
+        }
+        std::int32_t registryDisp = 0;
+        std::memcpy(&registryDisp, registryLoad + 3, sizeof(registryDisp));
+        g_panelRegistryGlobal = reinterpret_cast<void **>(
+            registryLoad + 7 + registryDisp);
+
+        auto makeSymbol = reinterpret_cast<MakeSymbolFn>(makeSymbolTarget);
+        makeSymbol(&g_specVisibleClass, "HudSpecplayerRoot--visible");
+        makeSymbol(&g_spectatingTargetClass, "HUD--spectating-target");
+
+        if (!g_takeoverHook.Install(takeoverTarget,
+                                    reinterpret_cast<void *>(&TakeoverDetour),
+                                    kTakeoverStealLen))
+        {
+            g_status = "failed: takeover hook install";
+            std::snprintf(errorOut, errorOutLen, "%s", g_status.c_str());
+            return false;
+        }
+        g_takeoverOriginal = reinterpret_cast<UpdateFn>(g_takeoverHook.Trampoline());
+
+        if (!g_specHook.Install(specTarget,
+                               reinterpret_cast<void *>(&SpecDetour),
+                               kSpecStealLen))
+        {
+            g_takeoverHook.Remove();
+            g_takeoverOriginal = nullptr;
+            g_status = "failed: spectator hook install";
+            std::snprintf(errorOut, errorOutLen, "%s", g_status.c_str());
+            return false;
+        }
+        g_specOriginal = reinterpret_cast<UpdateFn>(g_specHook.Trampoline());
+
+        g_status = "installed: managed bot POV HUD presentation";
+        return true;
+#endif
+    }
+
+    void Remove()
+    {
+        g_specHook.Remove();
+        g_takeoverHook.Remove();
+        g_takeoverOriginal = nullptr;
+        g_specOriginal = nullptr;
+        g_panelRegistryGlobal = nullptr;
+        g_specVisibleClass = 0;
+        g_spectatingTargetClass = 0;
+        g_status = "not installed";
+    }
+
+    const char *Status()
+    {
+        return g_status.c_str();
+    }
+} // namespace cs2bh::HudPovPresentation
+
+#undef BH_FASTCALL

--- a/src/hud_pov_presentation.h
+++ b/src/hud_pov_presentation.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstddef>
+
+#include <nlohmann/json.hpp>
+
+namespace cs2bh::HudPovPresentation
+{
+    // Optional local-client hook. client.dll is absent on dedicated servers.
+    bool Install(const nlohmann::json &gamedata, char *errorOut, size_t errorOutLen);
+    void Remove();
+    const char *Status();
+} // namespace cs2bh::HudPovPresentation

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -12,6 +12,7 @@
 #include "sig_scan.h"
 #include "schema_resolver.h"
 #include "inline_hook.h"
+#include "hud_pov_presentation.h"
 
 #include <cstdio>
 #include <cstdint>
@@ -1873,6 +1874,17 @@ namespace cs2bh
 
                 // Install the bot-quota flip-around detour
                 InstallQuotaHook(gamedata, serverModule);
+
+                // Optional local Windows client presentation. Dedicated
+                // servers do not load client.dll and continue without it.
+                char hudPovError[256] = {0};
+                HudPovPresentation::Install(
+                    gamedata, hudPovError, sizeof(hudPovError));
+                META_CONPRINTF("[BOTHIDER] client POV HUD: %s%s%s%s\n",
+                               HudPovPresentation::Status(),
+                               hudPovError[0] ? " (" : "",
+                               hudPovError[0] ? hudPovError : "",
+                               hudPovError[0] ? ")" : "");
             }
         }
         if (g_pfnUtilRemove)
@@ -2018,6 +2030,7 @@ namespace cs2bh
         g_pfnKickOneTramp = nullptr;
         g_QuotaHook.Remove();
         g_pfnQuotaTramp = nullptr;
+        HudPovPresentation::Remove();
         Manager().ReleaseAll();
         Publisher().Shutdown();
         return true;

--- a/src/slot_publisher.cpp
+++ b/src/slot_publisher.cpp
@@ -144,6 +144,25 @@ namespace cs2bh
         *gen = *gen + 1;
     }
 
+    bool SlotPublisher::ObserverPovActive() const
+    {
+        if (!m_pView)
+            return false;
+        const bool enabled = m_pView[shm::kOff_ObserverPovEnabled] != 0;
+        const auto mask = *reinterpret_cast<volatile const uint64_t *>(
+            m_pView + shm::kOff_ObserverPovMask);
+        return enabled && mask != 0;
+    }
+
+    bool SlotPublisher::TakePovActive() const
+    {
+        if (!m_pView)
+            return false;
+        const auto mask = *reinterpret_cast<volatile const uint64_t *>(
+            m_pView + shm::kOff_TakePovMask);
+        return mask != 0;
+    }
+
     // Data-region writers
 
     void SlotPublisher::PublishAdopt(int slot, uint64_t syntheticSid,

--- a/src/slot_publisher.h
+++ b/src/slot_publisher.h
@@ -35,6 +35,10 @@ namespace cs2bh
         void UpdatePersonaName(int slot, const char *name);
         void UpdatePing(int slot, int ping);
 
+        // Client HUD presentation state published by BotHiderImpl.
+        bool ObserverPovActive() const;
+        bool TakePovActive() const;
+
         // Append a signature/hook status entry (addr==0 means unresolved)
         void PublishSignature(const char *name, const void *addr);
 

--- a/src/slot_shm.h
+++ b/src/slot_shm.h
@@ -55,6 +55,14 @@ namespace cs2bh::shm
     inline constexpr int kOff_ScoreboardFlair = 10400; // uint32[64]
     // Ends at 10400 + 64*4 = 10656
 
+    // Local client HUD presentation state. BotHiderImpl publishes managed-slot
+    // masks and BotHider native consumes them. Observation is controlled by
+    // bh_ob_pov; takeover hiding is always enabled for managed bots.
+    inline constexpr int kOff_ObserverPovMask = 10656;    // uint64
+    inline constexpr int kOff_TakePovMask = 10664;        // uint64
+    inline constexpr int kOff_ObserverPovEnabled = 10672; // byte bool
+    inline constexpr int kOff_PovInitialized = 10674;     // byte marker
+
     inline constexpr int kTotalSize = 16384; // 4 pages
 
     // Command opcodes.


### PR DESCRIPTION
## What changed

- add a Windows listen-server `client.dll`/Panorama HUD hook directly to BotHider native
- publish independent observer and takeover masks for BotHider-managed slots through BotHider's existing shared-memory bridge
- add `bh_ob_pov true/false` (default `true`) to choose between the native spectator card and POV-style HUD while watching a managed bot in-eye
- always suppress the redundant bot-takeover notice for managed bots while leaving the normal health, armor, ammo, team emblem, and crosshair HUD unchanged

## Why

BotHider-managed bots already present human-like names and Steam identities. The vanilla spectator card and "controlling a bot" notice reveal that the target is still a bot and break first-person POV presentation.

Observer POV remains configurable because it removes useful spectator information. The takeover notice has no equivalent tradeoff, so it is always suppressed for managed bots.

The feature is self-contained in BotHider: BotHiderImpl determines the managed observer/takeover slot masks, and BotHider native performs the local Panorama presentation. Dedicated servers skip the client-only hook and remote clients are unaffected.

## Validation

- `dotnet build csharp/BotHiderImpl/BotHiderImpl.csproj -c Release`
- `cmake --build build --config Release`
- current Windows signatures uniquely match the verified 2026-07-10 `client.dll`
