### PR TITLE
fix: guard bot identity hooks during level teardown

### DIFF
--- a/csharp/BotHiderImpl/BotHiderImplPlugin.cs
+++ b/csharp/BotHiderImpl/BotHiderImplPlugin.cs
@@ -31,9 +31,14 @@ public class BotHiderImplPlugin : BasePlugin
     private CounterStrikeSharp.API.Modules.Timers.Timer? _fastApplyTimer;
     private int _fastApplyRemaining;
     private Harmony? _harmony;
+    private bool _mapActive;
+    private long _lifecycleGeneration;
 
     public override void Load(bool hotReload)
     {
+        _mapActive = true;
+        _lifecycleGeneration++;
+
         // Inject the visible-write actions so SetPersonaName / SetBotSteamId
         // also update the scoreboard
         _client = new SharedMemoryClient(
@@ -59,6 +64,9 @@ public class BotHiderImplPlugin : BasePlugin
 
     public override void Unload(bool hotReload)
     {
+        _mapActive = false;
+        _lifecycleGeneration++;
+
         // Undo the patch first
         _harmony?.UnpatchAll(_harmony.Id);
         _harmony = null;
@@ -67,11 +75,14 @@ public class BotHiderImplPlugin : BasePlugin
         _fastApplyTimer?.Kill();
         _fastApplyTimer = null;
         _client?.Dispose();
+        _client = null;
     }
 
     // Clears presentation caches when a new map starts
     private void OnMapStart(string mapName)
     {
+        _lifecycleGeneration++;
+        _mapActive = true;
         ResetAppliedState();
         StartFastApplyWindow();
     }
@@ -79,6 +90,10 @@ public class BotHiderImplPlugin : BasePlugin
     // Clears presentation caches when the current map ends
     private void OnMapEnd()
     {
+        _mapActive = false;
+        _lifecycleGeneration++;
+        _fastApplyTimer?.Kill();
+        _fastApplyTimer = null;
         ResetAppliedState();
     }
 
@@ -92,6 +107,8 @@ public class BotHiderImplPlugin : BasePlugin
     [GameEventHandler]
     public HookResult OnRoundStart(EventRoundStart @event, GameEventInfo info)
     {
+        if (!_mapActive)
+            return HookResult.Continue;
         StartFastApplyWindow();
         AddTimer(0.3f, RespawnDeadManagedBots);
         return HookResult.Continue;
@@ -101,6 +118,8 @@ public class BotHiderImplPlugin : BasePlugin
     [GameEventHandler]
     public HookResult OnPlayerConnectFull(EventPlayerConnectFull @event, GameEventInfo info)
     {
+        if (!_mapActive)
+            return HookResult.Continue;
         StartFastApplyWindow();
         return HookResult.Continue;
     }
@@ -109,6 +128,8 @@ public class BotHiderImplPlugin : BasePlugin
     [GameEventHandler]
     public HookResult OnPlayerSpawn(EventPlayerSpawn @event, GameEventInfo info)
     {
+        if (!_mapActive)
+            return HookResult.Continue;
         StartFastApplyWindow();
         return HookResult.Continue;
     }
@@ -117,6 +138,8 @@ public class BotHiderImplPlugin : BasePlugin
     [GameEventHandler]
     public HookResult OnPlayerDeath(EventPlayerDeath @event, GameEventInfo info)
     {
+        if (!_mapActive)
+            return HookResult.Continue;
         StartFastApplyWindow();
         return HookResult.Continue;
     }
@@ -125,60 +148,83 @@ public class BotHiderImplPlugin : BasePlugin
     [GameEventHandler]
     public HookResult OnVoteOptions(EventVoteOptions @event, GameEventInfo info)
     {
-        Server.NextFrame(AcceptVoteForManagedBots);
+        if (!_mapActive || _client == null)
+            return HookResult.Continue;
+
+        long generation = _lifecycleGeneration;
+        Server.NextFrame(() =>
+        {
+            if (!_mapActive || generation != _lifecycleGeneration)
+                return;
+            AcceptVoteForManagedBots(generation);
+        });
         return HookResult.Continue;
     }
 
     // Casts a yes vote from every valid managed bot
-    private void AcceptVoteForManagedBots()
+    private void AcceptVoteForManagedBots(long generation)
     {
-        if (_client == null) return;
+        if (!_mapActive || generation != _lifecycleGeneration || _client == null)
+            return;
 
         var voteController = Utilities
             .FindAllEntitiesByDesignerName<CVoteController>("vote_controller")
             .FirstOrDefault(controller => controller.IsValid);
-        if (voteController == null)
+        if (voteController == null || !voteController.IsValid || voteController.ActiveIssueIndex < 0)
         {
-            Server.PrintToConsole("[BotHider] automatic vote failed: vote controller not found");
             return;
         }
 
-        Span<int> votesCast = voteController.VotesCast;
-        Span<int> optionCounts = voteController.VoteOptionCount;
-        int onlyTeam = voteController.OnlyTeamToVote;
-        int accepted = 0;
-
-        foreach (int slot in _client.GetManagedSlots())
+        try
         {
-            if ((uint)slot >= (uint)votesCast.Length) continue;
+            Span<int> votesCast = voteController.VotesCast;
+            Span<int> optionCounts = voteController.VoteOptionCount;
+            if (votesCast.Length == 0 || optionCounts.Length == 0)
+                return;
 
-            var player = Utilities.GetPlayerFromSlot(slot);
-            if (player == null || !player.IsValid) continue;
-            if (onlyTeam >= (int)CsTeam.Terrorist && (int)player.Team != onlyTeam) continue;
-
-            votesCast[slot] = 0;
-            accepted++;
-
-            var voteEvent = new EventVoteCast(true)
+            int onlyTeam = voteController.OnlyTeamToVote;
+            int accepted = 0;
+            foreach (int slot in _client.GetManagedSlots())
             {
-                Team = onlyTeam,
-                Userid = player,
-                VoteOption = 0
-            };
-            voteEvent.FireEvent(false);
-        }
+                if ((uint)slot >= (uint)votesCast.Length) continue;
 
-        if (accepted == 0) return;
-        optionCounts[0] += accepted;
-        Utilities.SetStateChanged(
-            voteController, "CVoteController", "m_nVoteOptionCount");
-        Server.PrintToConsole($"[BotHider] automatic yes votes cast={accepted}");
+                var player = Utilities.GetPlayerFromSlot(slot);
+                if (player == null || !player.IsValid) continue;
+                if (onlyTeam >= (int)CsTeam.Terrorist && (int)player.Team != onlyTeam) continue;
+
+                votesCast[slot] = 0;
+                accepted++;
+
+                var voteEvent = new EventVoteCast(true)
+                {
+                    Team = onlyTeam,
+                    Userid = player,
+                    VoteOption = 0
+                };
+                voteEvent.FireEvent(false);
+            }
+
+            if (accepted == 0 || !_mapActive || generation != _lifecycleGeneration || !voteController.IsValid)
+                return;
+            if (optionCounts[0] > int.MaxValue - accepted)
+            {
+                Server.PrintToConsole("[BotHider] automatic vote skipped: vote count overflow");
+                return;
+            }
+            optionCounts[0] += accepted;
+            Utilities.SetStateChanged(voteController, "CVoteController", "m_nVoteOptionCount");
+            Server.PrintToConsole($"[BotHider] automatic yes votes cast={accepted}");
+        }
+        catch (Exception e)
+        {
+            Server.PrintToConsole($"[BotHider] automatic vote skipped during controller update: {e.Message}");
+        }
     }
 
     // Respawn any managed bot that is not alive
     private void RespawnDeadManagedBots()
     {
-        if (_client == null) return;
+        if (!_mapActive || _client == null) return;
 
         // Current team headcount across everyone, for balancing unassigned bots
         int tCount = 0, ctCount = 0;
@@ -222,10 +268,12 @@ public class BotHiderImplPlugin : BasePlugin
     }
 
     // Set CCSPlayerController.m_iszPlayerName
-    private static void ApplyVisibleName(int slot, string name)
+    private void ApplyVisibleName(int slot, string name)
     {
+        long generation = _lifecycleGeneration;
         Server.NextFrame(() =>
         {
+            if (!_mapActive || generation != _lifecycleGeneration) return;
             var player = Utilities.GetPlayerFromSlot(slot);
             if (player == null || !player.IsValid) return;
             player.PlayerName = name;
@@ -234,10 +282,12 @@ public class BotHiderImplPlugin : BasePlugin
     }
 
     // Write CBasePlayerController.m_steamID
-    private static void ApplyVisibleSid(int slot, ulong sid)
+    private void ApplyVisibleSid(int slot, ulong sid)
     {
+        long generation = _lifecycleGeneration;
         Server.NextFrame(() =>
         {
+            if (!_mapActive || generation != _lifecycleGeneration) return;
             var player = Utilities.GetPlayerFromSlot(slot);
             if (player == null || !player.IsValid) return;
             try
@@ -253,10 +303,12 @@ public class BotHiderImplPlugin : BasePlugin
     }
 
     // Write CCSPlayerController.m_szCrosshairCodes
-    private static void ApplyVisibleCrosshair(int slot, string code)
+    private void ApplyVisibleCrosshair(int slot, string code)
     {
+        long generation = _lifecycleGeneration;
         Server.NextFrame(() =>
         {
+            if (!_mapActive || generation != _lifecycleGeneration) return;
             var player = Utilities.GetPlayerFromSlot(slot);
             if (player == null || !player.IsValid) return;
             try
@@ -274,8 +326,10 @@ public class BotHiderImplPlugin : BasePlugin
     // Write CCSPlayerController_InventoryServices.m_rank
     private void ApplyVisibleScoreboardFlair(int slot, uint itemDefIndex)
     {
+        long generation = _lifecycleGeneration;
         Server.NextFrame(() =>
         {
+            if (!_mapActive || generation != _lifecycleGeneration) return;
             if (TryApplyScoreboardFlair(slot, itemDefIndex))
                 _appliedScoreboardFlair[slot] = itemDefIndex;
         });
@@ -284,6 +338,7 @@ public class BotHiderImplPlugin : BasePlugin
     // Opens a short high-frequency apply window for early-round fields
     private void StartFastApplyWindow()
     {
+        if (!_mapActive) return;
         _fastApplyRemaining = Math.Max(_fastApplyRemaining, 80);
         if (_fastApplyTimer != null) return;
         _fastApplyTimer = AddTimer(0.25f, RunFastApplyTick, TimerFlags.REPEAT | TimerFlags.STOP_ON_MAPCHANGE);
@@ -292,6 +347,8 @@ public class BotHiderImplPlugin : BasePlugin
     // Runs one early apply retry tick
     private void RunFastApplyTick()
     {
+        if (!_mapActive)
+            return;
         ApplyManagedSlots();
         _fastApplyRemaining--;
         if (_fastApplyRemaining > 0) return;
@@ -318,7 +375,7 @@ public class BotHiderImplPlugin : BasePlugin
     // Timer body
     private void ApplyManagedSlots()
     {
-        if (_client == null) return;
+        if (!_mapActive || _client == null) return;
         int[] managedSlots = _client.GetManagedSlots();
         var managed = new bool[64];
         foreach (int slot in managedSlots)

--- a/src/BotIdentity/client_hooks.cpp
+++ b/src/BotIdentity/client_hooks.cpp
@@ -1,5 +1,3 @@
-#include "network_connection.pb.h"
-#include "playerslot.h"
 #include "plugin.h"
 
 #include "bot_info.h"
@@ -11,18 +9,16 @@
 #include "personas.h"
 #include "serversideclient_ref.h"
 #include "slot_publisher.h"
-#include "steam/steamtypes.h"
-#include "sourcehook.h"
 
 #include <cstdint>
 #include <string>
 
+#include <iserver.h>
+
 namespace cs2bh {
 
-namespace {
-
 // Checks whether a disconnect may leave its controller behind
-bool IsTargetedClientRemovalReason(ENetworkDisconnectionReason reason)
+static bool IsTargetedClientRemovalReason(ENetworkDisconnectionReason reason)
 {
     switch (reason)
     {
@@ -39,18 +35,11 @@ bool IsTargetedClientRemovalReason(ENetworkDisconnectionReason reason)
            value <= static_cast<int>(NETWORK_DISCONNECT_KICKED_INSECURECLIENT);
 }
 
-} // namespace
-
 // Adopts fake clients from the authoritative connected slot
-void HiderPlugin::HookOnClientConnectedPost( // NOLINT(readability-make-member-function-const)
-    CPlayerSlot slot,
-    const char* name,
-    uint64 /*xuid*/,
-    const char* networkId,
-    const char* /*address*/,
-    bool fakePlayer)
+void HiderPlugin::HookOnClientConnectedPost(
+    CPlayerSlot slot, const char* pszName, uint64 /*xuid*/, const char* pszNetworkID, const char* /*pszAddress*/, bool bFakePlayer)
 {
-    if (m_selfDisabled || !fakePlayer || identity_runtime::IsHltvConnection(name, networkId))
+    if (m_selfDisabled || !IsLifecycleActive() || !bFakePlayer || identity_runtime::IsHltvConnection(pszName, pszNetworkID))
     {
         RETURN_META(MRES_IGNORED);
     }
@@ -64,13 +53,15 @@ void HiderPlugin::HookOnClientConnectedPost( // NOLINT(readability-make-member-f
     void* client = entity_access::ResolveClientBySlot(index);
     if (!client || ssc::IsHltv(client)) RETURN_META(MRES_IGNORED);
 
-    const BotEntry* entry = BotInfo().PickForBot(name);
+    const BotEntry* entry = BotInfo().PickForBot(pszName);
     std::string displayName;
-    if (entry && (m_useBotInfoName || !name || !name[0])) displayName = entry->name;
-    else if (name && name[0])
-        displayName = name;
+    if (m_useBotInfoName && entry) displayName = entry->name;
+    else if (pszName && pszName[0])
+        displayName = pszName;
+    else if (entry)
+        displayName = entry->name;
     else
-        displayName = entry ? entry->name : Personas().PickFromRoster();
+        displayName = Personas().PickFromRoster();
 
     if (displayName.empty())
     {
@@ -88,7 +79,7 @@ void HiderPlugin::HookOnClientConnectedPost( // NOLINT(readability-make-member-f
         RETURN_META(MRES_IGNORED);
     }
 
-    identity_state::BindSlot(index, entry, name);
+    identity_state::BindSlot(index, entry, pszName);
 
     if (steamId != 0)
     {
@@ -107,12 +98,9 @@ void HiderPlugin::HookOnClientConnectedPost( // NOLINT(readability-make-member-f
 }
 
 // Reapplies managed identity after a client enters the server
-void HiderPlugin::HookClientPutInServerPost(CPlayerSlot slot,
-                                            char const* name,
-                                            int type,
-                                            uint64 /*xuid*/) // NOLINT(readability-make-member-function-const)
+void HiderPlugin::HookClientPutInServerPost(CPlayerSlot slot, char const* pszName, int type, uint64 /*xuid*/)
 {
-    if (m_selfDisabled) RETURN_META(MRES_IGNORED);
+    if (m_selfDisabled || !IsLifecycleActive()) RETURN_META(MRES_IGNORED);
 
     (void)type;
     const int index = slot.Get();
@@ -144,7 +132,7 @@ void HiderPlugin::HookClientPutInServerPost(CPlayerSlot slot,
     }
 
     std::string visibleName = Personas().GetSlotName(index);
-    if (visibleName.empty() && name) visibleName = name;
+    if (visibleName.empty() && pszName) visibleName = pszName;
     if (!visibleName.empty())
     {
         entity_access::SetEngineName(client, visibleName.c_str());
@@ -158,16 +146,25 @@ void HiderPlugin::HookClientPutInServerPost(CPlayerSlot slot,
 }
 
 // Restores and releases managed identity before disconnect teardown
-void HiderPlugin::HookClientDisconnectPre( // NOLINT(readability-make-member-function-const)
-    CPlayerSlot slot,
-    ENetworkDisconnectionReason reason,
-    const char* /*name*/,
-    uint64 /*xuid*/,
-    const char* /*networkId*/)
+void HiderPlugin::HookClientDisconnectPre(
+    CPlayerSlot slot, ENetworkDisconnectionReason reason, const char* /*pszName*/, uint64 /*xuid*/, const char* /*pszNetworkID*/)
 {
     if (m_selfDisabled) RETURN_META(MRES_IGNORED);
 
     const int index = slot.Get();
+    if (!IsLifecycleActive())
+    {
+        // During teardown the client pointer may already be invalid. Release
+        // only BotHider-owned containers; level shutdown drains the rest.
+        if (index >= 0 && index < PersonaPool::kMaxSlots && Personas().IsSlotManaged(index))
+        {
+            BotInfo().ReleaseAssignment(identity_state::SlotEntry(index));
+            identity_state::ClearSlot(index);
+            Manager().ReleaseSlot(index);
+        }
+        RETURN_META(MRES_IGNORED);
+    }
+
     if (index < 0 || index >= PersonaPool::kMaxSlots || !Personas().IsSlotManaged(index))
     {
         RETURN_META(MRES_IGNORED);

--- a/src/BotIdentity/command_hooks.cpp
+++ b/src/BotIdentity/command_hooks.cpp
@@ -1,4 +1,3 @@
-#include "ISmmPlugin.h"
 #include "plugin.h"
 
 #include "avatar_override.h"
@@ -11,46 +10,42 @@
 #include "personas.h"
 #include "serversideclient_ref.h"
 #include "slot_publisher.h"
-#include "sourcehook.h"
-#include "utlvector.h"
 
-#include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <string>
 
 #include <eiface.h>
 #include <iserver.h>
 #include <tier1/convar.h>
 
-extern IVEngineServer* g_engine;
+extern IVEngineServer* engine;
 
 namespace cs2bh {
 
-namespace {
-
 // Returns whether a console command disconnects a client
-bool IsKickCommand(const char* name)
+static bool IsKickCommand(const char* name)
 {
     if (!name || !name[0]) return false;
     return !std::strcmp(name, "kickid") || !std::strcmp(name, "kick") || !std::strcmp(name, "bot_kick") || !std::strcmp(name, "banid");
 }
 
 // Returns whether a command adds a bot
-bool IsBotAddCommand(const char* name)
+static bool IsBotAddCommand(const char* name)
 {
     if (!name || !name[0]) return false;
     return !std::strcmp(name, "bot_add") || !std::strcmp(name, "bot_add_t") || !std::strcmp(name, "bot_add_ct");
 }
 
 // Returns whether a bot_kick target is a built-in group
-bool IsBotKickGroupTarget(const char* target)
+static bool IsBotKickGroupTarget(const char* target)
 {
     if (!target || !target[0]) return false;
     return !std::strcmp(target, "all") || !std::strcmp(target, "t") || !std::strcmp(target, "ct");
 }
 
 // Finds a managed slot from its current persona name
-int FindManagedSlotByPersonaName(const char* name)
+static int FindManagedSlotByPersonaName(const char* name)
 {
     if (!name || !name[0]) return -1;
     for (int slot = 0; slot < PersonaPool::kMaxSlots; ++slot)
@@ -61,21 +56,16 @@ int FindManagedSlotByPersonaName(const char* name)
     return -1;
 }
 
-} // namespace
-
 // Opens one identity transaction for the complete engine population command.
 void HiderPlugin::HookDispatchConCommandPre(ConCommandRef command, const CCommandContext&, const CCommand& arguments)
 {
-    if (m_selfDisabled || !command.IsValidRef()) RETURN_META(MRES_IGNORED);
+    if (m_selfDisabled || !IsLifecycleActive() || !command.IsValidRef()) RETURN_META(MRES_IGNORED);
     const char* commandName = command.GetName();
 
     if (IsBotAddCommand(commandName))
     {
-        if (IsDisguiseEnabled())
-        {
-            identity_hooks::BeginPopulationTransaction(true);
-            ++m_populationCommandDepth;
-        }
+        identity_hooks::BeginPopulationTransaction(IsDisguiseEnabled());
+        ++m_populationCommandDepth;
         RETURN_META(MRES_IGNORED);
     }
 
@@ -85,11 +75,11 @@ void HiderPlugin::HookDispatchConCommandPre(ConCommandRef command, const CComman
         if (target[0] && !IsBotKickGroupTarget(target))
         {
             const int slot = FindManagedSlotByPersonaName(target);
-            if (slot >= 0 && g_engine)
+            if (slot >= 0 && engine)
             {
                 char kickCommand[640];
                 std::snprintf(kickCommand, sizeof(kickCommand), "kick \"%s\"\n", target);
-                g_engine->ServerCommand(kickCommand);
+                engine->ServerCommand(kickCommand);
                 RETURN_META(MRES_SUPERCEDE);
             }
         }
@@ -97,18 +87,15 @@ void HiderPlugin::HookDispatchConCommandPre(ConCommandRef command, const CComman
 
     if (!IsKickCommand(commandName)) RETURN_META(MRES_IGNORED);
 
-    if (IsDisguiseEnabled())
-    {
-        identity_hooks::BeginPopulationTransaction(true);
-        ++m_populationCommandDepth;
-    }
+    identity_hooks::BeginPopulationTransaction(IsDisguiseEnabled());
+    ++m_populationCommandDepth;
     RETURN_META(MRES_IGNORED);
 }
 
 // Closes the transaction after the engine command and any nested quota pass complete.
 void HiderPlugin::HookDispatchConCommandPost(ConCommandRef command, const CCommandContext&, const CCommand& /*arguments*/)
 {
-    if (m_selfDisabled || !command.IsValidRef()) RETURN_META(MRES_IGNORED);
+    if (m_selfDisabled || !IsLifecycleActive() || !command.IsValidRef()) RETURN_META(MRES_IGNORED);
     const char* commandName = command.GetName();
 
     if (IsBotAddCommand(commandName))
@@ -133,6 +120,7 @@ void HiderPlugin::HookDispatchConCommandPost(ConCommandRef command, const CComma
 // Changes the global managed-bot identity mode
 void HiderPlugin::SetIdentityMode(IdentityMode mode)
 {
+    if (!IsLifecycleActive()) return;
     if (m_identityMode == mode) return;
     m_identityMode = mode;
     identity_runtime::ApplyManagedDisguise(mode == IdentityMode::Player);
@@ -140,25 +128,32 @@ void HiderPlugin::SetIdentityMode(IdentityMode mode)
 }
 
 // Restores native bot identity and clears managed state before a level transition
-CUtlVector<INetworkGameClient*>* HiderPlugin::HookStartChangeLevelPre(
-    const char* mapName, const char* landmark, void* /*changelevelState*/) // NOLINT(readability-make-member-function-const)
+CUtlVector<INetworkGameClient*>*
+HiderPlugin::HookStartChangeLevelPre(const char* mapName, const char* landmark, void* /*changelevelState*/)
 {
     if (m_selfDisabled) RETURN_META_VALUE(MRES_IGNORED, nullptr);
 
-    const int restoredClients = identity_runtime::RestoreManagedClientsForEngineTeardown();
+    const bool restoreOwner = BeginLifecycleTeardown();
+    int restoredClients = 0;
+    if (restoreOwner)
+    {
+        restoredClients = identity_runtime::RestoreManagedClientsForEngineTeardown();
+        EndLifecycleTeardown();
+    }
     identity_state::ClearAll();
     Manager().ReleaseAll();
-    avatar::ProcessOverrides();
+    identity_runtime::ClearPendingControllerRemovals();
+    avatar::ResetRuntime();
     BotInfo().ResetAssignments();
-    META_CONPRINTF("[BOTHIDER] StartChangeLevel PRE restored=%d map='%s' landmark='%s'\n", restoredClients, mapName ? mapName : "?",
-                   landmark ? landmark : "");
+    META_CONPRINTF("[BOTHIDER] StartChangeLevel PRE restored=%d map='%s' landmark='%s'\n", restoredClients,
+                   mapName ? mapName : "?", landmark ? landmark : "");
     RETURN_META_VALUE(MRES_IGNORED, nullptr);
 }
 
 // Drives deferred cleanup and shared-memory commands each frame
-void HiderPlugin::HookGameFramePost(bool simulating, bool /*firstTick*/, bool /*lastTick*/)
+void HiderPlugin::HookGameFramePost(bool simulating, bool /*bFirst*/, bool /*bLast*/)
 {
-    if (m_selfDisabled || !simulating) RETURN_META(MRES_IGNORED);
+    if (m_selfDisabled || !IsLifecycleActive() || !simulating) RETURN_META(MRES_IGNORED);
 
     identity_runtime::DrainPendingControllerRemovals();
     for (int slot = 0; slot < PersonaPool::kMaxSlots; ++slot)
@@ -172,7 +167,7 @@ void HiderPlugin::HookGameFramePost(bool simulating, bool /*firstTick*/, bool /*
     }
     Manager().OnTick();
 
-    if ((++m_tickCounter & 63U) == 0U)
+    if ((++m_tickCounter & 63u) == 0u)
     {
         for (int slot = 0; slot < PersonaPool::kMaxSlots; ++slot)
         {

--- a/src/BotIdentity/identity_hooks.cpp
+++ b/src/BotIdentity/identity_hooks.cpp
@@ -1,30 +1,26 @@
 #include "identity_hooks.h"
 
-#include "ISmmPlugin.h"
 #include "entity_access.h"
 #include "fake_client_manager.h"
 #include "identity_runtime.h"
-#include "nlohmann/json.hpp"
 #include "personas.h"
-#include "plugin.h"
 #include "serversideclient_ref.h"
-#include "sig_scan.h"
 #include "version_targets.h"
 
-#include <cstdint>
-#include <array>
+#include <atomic>
+#include <condition_variable>
 #include <cstring>
 #include <limits>
 #include <memory>
 #include <mutex>
-#include <utility>
 #include <string>
 #include <vector>
 
 #include <entity2/entityinstance.h>
 #include <funchook.h>
 
-#ifdef _WIN32
+#if defined(_WIN32)
+#include <intrin.h>
 #define CS2BH_FASTCALL __fastcall
 #else
 #define CS2BH_FASTCALL
@@ -32,33 +28,35 @@
 
 namespace cs2bh::identity_hooks {
 
-namespace {
-
 using MaintainQuotaFn = int64_t(CS2BH_FASTCALL*)(void*);
 using HandleJoinTeamFn = int64_t(CS2BH_FASTCALL*)(void*, unsigned int, bool);
 using ApplyHumanTeamRestrictionFn = int64_t(CS2BH_FASTCALL*)();
 using PackEntitiesFn = void(CS2BH_FASTCALL*)(void*, void*, int, void*, void*);
 using SameMapClientCollectorFn = void*(CS2BH_FASTCALL*)(void*, uintptr_t);
 
-funchook_t* g_funchook = nullptr;
-size_t g_preparedFunchookCount = 0;
-bool g_funchooksInstalled = false;
+static funchook_t* g_funchook = nullptr;
+static size_t g_preparedFunchookCount = 0;
+static bool g_funchooksInstalled = false;
 
-MaintainQuotaFn g_quotaTrampoline = nullptr;
-void* g_quotaHookTarget = nullptr;
-HandleJoinTeamFn g_handleJoinTeamTrampoline = nullptr;
-void* g_handleJoinTeamHookTarget = nullptr;
-ApplyHumanTeamRestrictionFn g_applyHumanTeamRestrictionTrampoline = nullptr;
-void* g_applyHumanTeamRestrictionHookTarget = nullptr;
-PackEntitiesFn g_packEntitiesTrampoline = nullptr;
-void* g_packEntitiesHookTarget = nullptr;
-SameMapClientCollectorFn g_sameMapCollectorTrampoline = nullptr;
-void* g_sameMapTeardownHookTarget = nullptr;
-void* g_sameMapTeardownReturnAddress = nullptr;
-std::recursive_mutex g_packEntitiesMutex;
-thread_local uint32_t g_packEntitiesDepth = 0;
-std::array<bool, 64> g_quotaResolveWarned{};
-bool g_quotaInvalidOffsetWarned = false;
+static MaintainQuotaFn g_quotaTrampoline = nullptr;
+static void* g_quotaHookTarget = nullptr;
+static HandleJoinTeamFn g_handleJoinTeamTrampoline = nullptr;
+static void* g_handleJoinTeamHookTarget = nullptr;
+static ApplyHumanTeamRestrictionFn g_applyHumanTeamRestrictionTrampoline = nullptr;
+static void* g_applyHumanTeamRestrictionHookTarget = nullptr;
+static PackEntitiesFn g_packEntitiesTrampoline = nullptr;
+static void* g_packEntitiesHookTarget = nullptr;
+static SameMapClientCollectorFn g_sameMapCollectorTrampoline = nullptr;
+static void* g_sameMapTeardownHookTarget = nullptr;
+static void* g_sameMapTeardownReturnAddress = nullptr;
+static std::recursive_mutex g_packEntitiesMutex;
+static std::atomic_uint g_FunchookInFlight = 0;
+static std::mutex g_FunchookFlightMutex;
+static std::condition_variable g_FunchookFlightCv;
+static thread_local uint32_t g_packEntitiesDepth = 0;
+static thread_local uint32_t g_FunchookDepth = 0;
+static std::array<bool, 64> g_quotaResolveWarned{};
+static bool g_quotaInvalidOffsetWarned = false;
 
 struct NativeBotIdentitySnapshot
 {
@@ -74,29 +72,38 @@ struct NativeBotIdentitySnapshot
     bool modified = false;
 };
 
-bool IsValidController(void* controller, const char* className, uint32_t handle)
+static bool IsValidController(void* controller, const char* className, uint32_t handle)
 {
     return controller && className && std::strcmp(className, "cs_player_controller") == 0 &&
            !entity_access::IsEntityBeingDeleted(controller) &&
-           std::cmp_equal(static_cast<uint32_t>(reinterpret_cast<CEntityInstance*>(controller)->GetRefEHandle().ToInt()), handle);
+           static_cast<uint32_t>(reinterpret_cast<CEntityInstance*>(controller)->GetRefEHandle().ToInt()) == handle;
 }
 
 class ScopedNativeBotIdentityRestore
 {
   public:
     ScopedNativeBotIdentityRestore() { Capture(); }
-    ~ScopedNativeBotIdentityRestore() { Restore(); }
+    ~ScopedNativeBotIdentityRestore()
+    {
+        if (!m_discarded) Restore();
+    }
+
+    // Teardown invalidates the entity pointers captured by this snapshot. Do
+    // not run the normal restore path after that point.
+    void Discard() { m_discarded = true; }
 
     int ModifiedCount() const { return m_modifiedCount; }
 
   private:
     std::array<NativeBotIdentitySnapshot, 64> m_snapshots{};
     int m_modifiedCount = 0;
+    bool m_discarded = false;
 
     void Capture()
     {
         if (ssc::g_userIdOffset < 0 || ssc::g_entityIndexOffset < 0 || ssc::g_netChannelOffset < 0 ||
-            ssc::g_connectionTypeFlagsOffset < 0 || ssc::g_fakePlayerOffset < 0 || targets::g_controllerFakeClientFlagsOffset < 0)
+            ssc::g_connectionTypeFlagsOffset < 0 || ssc::g_fakePlayerOffset < 0 ||
+            targets::g_controllerFakeClientFlagsOffset < 0)
         {
             if (!g_quotaInvalidOffsetWarned)
             {
@@ -149,8 +156,8 @@ class ScopedNativeBotIdentityRestore
             }
             if (std::strcmp(className, "cs_player_controller") != 0 || entity_access::IsEntityBeingDeleted(snapshot.controller))
             {
-                META_CONPRINTF("[BOTHIDER] warning: quota identity restore invalid controller slot=%d userid=%u entIdx=%d cls='%s'\n", slot,
-                               static_cast<unsigned int>(snapshot.userId), entityIndex, className);
+                META_CONPRINTF("[BOTHIDER] warning: quota identity restore invalid controller slot=%d userid=%u entIdx=%d cls='%s'\n",
+                               slot, static_cast<unsigned int>(snapshot.userId), entityIndex, className);
                 g_quotaResolveWarned[slot] = true;
                 snapshot.controller = nullptr;
                 continue;
@@ -165,12 +172,13 @@ class ScopedNativeBotIdentityRestore
             snapshot.controllerFlags = *flags;
             snapshot.hasController = true;
             const uint32_t before = *flags;
-            *flags |= 0x100U;
+            *flags |= 0x100u;
             if (*flags != before)
             {
                 entity_access::MarkEntityFieldChanged(snapshot.controller,
-                                                      static_cast<uint32_t>(targets::g_controllerFakeClientFlagsOffset));
+                                                       static_cast<uint32_t>(targets::g_controllerFakeClientFlagsOffset));
             }
+
         }
     }
 
@@ -205,27 +213,26 @@ class ScopedNativeBotIdentityRestore
             void* controller = entity_access::ResolveEntityInstance(entityIndex, className, sizeof(className));
             if (!IsValidController(controller, className, snapshot.handle) || controller != snapshot.controller)
             {
-                META_CONPRINTF("[BOTHIDER] warning: quota identity restore skipped slot=%d userid=%u: controller rebound\n", snapshot.slot,
-                               static_cast<unsigned int>(snapshot.userId));
+                META_CONPRINTF("[BOTHIDER] warning: quota identity restore skipped slot=%d userid=%u: controller rebound\n",
+                               snapshot.slot, static_cast<unsigned int>(snapshot.userId));
                 continue;
             }
 
-            auto* flags =
-                reinterpret_cast<uint32_t*>(reinterpret_cast<unsigned char*>(controller) + targets::g_controllerFakeClientFlagsOffset);
+            auto* flags = reinterpret_cast<uint32_t*>(reinterpret_cast<unsigned char*>(controller) +
+                                                      targets::g_controllerFakeClientFlagsOffset);
             if (*flags != snapshot.controllerFlags)
             {
                 *flags = snapshot.controllerFlags;
-                entity_access::MarkEntityFieldChanged(controller, static_cast<uint32_t>(targets::g_controllerFakeClientFlagsOffset));
+                entity_access::MarkEntityFieldChanged(controller,
+                                                       static_cast<uint32_t>(targets::g_controllerFakeClientFlagsOffset));
             }
         }
     }
 };
 
-unsigned int g_populationTransactionDepth = 0;
-bool g_populationTransactionRedisguise = false;
-std::unique_ptr<ScopedNativeBotIdentityRestore> g_populationIdentity;
-
-} // namespace
+static unsigned int g_populationTransactionDepth = 0;
+static bool g_populationTransactionRedisguise = false;
+static std::unique_ptr<ScopedNativeBotIdentityRestore> g_populationIdentity;
 
 void BeginPopulationTransaction(bool redisguise)
 {
@@ -254,10 +261,19 @@ void EndPopulationTransaction(bool redisguise)
     const bool applyDisguise = g_populationTransactionRedisguise;
     g_populationTransactionRedisguise = false;
     g_populationIdentity.reset();
-    if (applyDisguise) identity_runtime::ApplyManagedDisguise(g_plugin.IsDisguiseEnabled());
+    if (applyDisguise && g_plugin.IsLifecycleActive())
+        identity_runtime::ApplyManagedDisguise(g_plugin.IsDisguiseEnabled());
 }
 
 bool PopulationTransactionActive() { return g_populationTransactionDepth != 0; }
+
+void ResetPopulationTransaction()
+{
+    if (g_populationIdentity) g_populationIdentity->Discard();
+    g_populationIdentity.reset();
+    g_populationTransactionDepth = 0;
+    g_populationTransactionRedisguise = false;
+}
 
 PopulationTransactionScope::PopulationTransactionScope(bool redisguise) : m_redisguise(redisguise)
 {
@@ -265,8 +281,6 @@ PopulationTransactionScope::PopulationTransactionScope(bool redisguise) : m_redi
 }
 
 PopulationTransactionScope::~PopulationTransactionScope() { EndPopulationTransaction(m_redisguise); }
-
-namespace {
 
 class PackEntitiesDepthGuard
 {
@@ -278,43 +292,78 @@ class PackEntitiesDepthGuard
     ~PackEntitiesDepthGuard() { --g_packEntitiesDepth; }
 };
 
+class FunchookFlightGuard
+{
+  public:
+    FunchookFlightGuard()
+    {
+        ++g_FunchookDepth;
+        g_FunchookInFlight.fetch_add(1, std::memory_order_acq_rel);
+    }
+
+    ~FunchookFlightGuard()
+    {
+        if (g_FunchookInFlight.fetch_sub(1, std::memory_order_acq_rel) == 1)
+            g_FunchookFlightCv.notify_all();
+        --g_FunchookDepth;
+    }
+};
+
+static void WaitForFunchookDetours()
+{
+    std::unique_lock<std::mutex> lock(g_FunchookFlightMutex);
+    g_FunchookFlightCv.wait(lock, [] {
+        return g_FunchookInFlight.load(std::memory_order_acquire) == 0;
+    });
+}
+
 class ScopedBotFlagOverride
 {
   public:
     // Clears FL_BOT and marks changed fields before entity packing
-    ScopedBotFlagOverride() : m_modifiedPawns(ApplyBotFlagOverride()) {}
+    ScopedBotFlagOverride() : m_ModifiedPawns(ApplyBotFlagOverride()) {}
 
     // Restores only FL_BOT after entity packing without marking changes
-    ~ScopedBotFlagOverride() { RestoreBotFlagOverride(m_modifiedPawns); }
+    ~ScopedBotFlagOverride() { RestoreBotFlagOverride(m_ModifiedPawns); }
 
   private:
-    std::vector<BotPawnRef> m_modifiedPawns;
+    std::vector<BotPawnRef> m_ModifiedPawns;
 };
 
 // Passes entity packing through with a scoped FL_BOT override
-void CS2BH_FASTCALL DetourPackEntities(void* serverObject, void* packContext, int clientCount, void* clients, void* snapshotContext)
+static void CS2BH_FASTCALL Detour_PackEntities(void* serverObject, void* packContext, int clientCount, void* clients, void* snapshotContext)
 {
+    FunchookFlightGuard flightGuard;
     std::lock_guard<std::recursive_mutex> lock(g_packEntitiesMutex);
+    PackEntitiesFn trampoline = g_packEntitiesTrampoline;
+    if (!trampoline) return;
+    if (!g_plugin.IsLifecycleActive())
+    {
+        trampoline(serverObject, packContext, clientCount, clients, snapshotContext);
+        return;
+    }
+
     if (g_packEntitiesDepth != 0)
     {
-        g_packEntitiesTrampoline(serverObject, packContext, clientCount, clients, snapshotContext);
+        trampoline(serverObject, packContext, clientCount, clients, snapshotContext);
         return;
     }
 
     PackEntitiesDepthGuard depthGuard;
     ScopedBotFlagOverride flagOverride;
-    g_packEntitiesTrampoline(serverObject, packContext, clientCount, clients, snapshotContext);
+    trampoline(serverObject, packContext, clientCount, clients, snapshotContext);
 }
 
 // Restores managed clients only at the same-map teardown call site
-void* CS2BH_FASTCALL DetourSameMapClientCollector(void* collection, uintptr_t source)
+static void* CS2BH_FASTCALL Detour_SameMapClientCollector(void* collection, uintptr_t source)
 {
-#ifdef _MSC_VER
+    FunchookFlightGuard flightGuard;
+#if defined(_MSC_VER)
     void* returnAddress = _ReturnAddress();
 #else
     void* returnAddress = __builtin_extract_return_addr(__builtin_return_address(0));
 #endif
-    if (returnAddress == g_sameMapTeardownReturnAddress)
+    if (g_plugin.IsLifecycleActive() && returnAddress == g_sameMapTeardownReturnAddress)
     {
         const int restored = identity_runtime::RestoreManagedClientsForEngineTeardown();
         META_CONPRINTF("[BOTHIDER] same-map teardown PRE restored=%d\n", restored);
@@ -324,7 +373,7 @@ void* CS2BH_FASTCALL DetourSameMapClientCollector(void* collection, uintptr_t so
 }
 
 // Prepares one target and replaces its original pointer with the trampoline
-template <typename Function> bool PrepareFunchook(Function& original, void* target, void* detour, const char* name)
+template <typename Function> static bool PrepareFunchook(Function& original, void* target, void* detour, const char* name)
 {
     if (!g_funchook)
     {
@@ -351,7 +400,7 @@ template <typename Function> bool PrepareFunchook(Function& original, void* targ
 }
 
 // Clears all published hook targets and trampoline pointers
-void ClearBindings()
+static void ClearBindings()
 {
     g_quotaTrampoline = nullptr;
     g_packEntitiesTrampoline = nullptr;
@@ -369,39 +418,42 @@ void ClearBindings()
 }
 
 // Restores Bot identity while the engine counts bot quota
-int64_t CS2BH_FASTCALL DetourMaintainBotQuota(void* manager)
+static int64_t CS2BH_FASTCALL Detour_MaintainBotQuota(void* manager)
 {
-    if (!g_plugin.IsDisguiseEnabled()) return g_quotaTrampoline ? g_quotaTrampoline(manager) : 0;
-    PopulationTransactionScope scope(true);
+    FunchookFlightGuard flightGuard;
+    if (!g_plugin.IsLifecycleActive()) return g_quotaTrampoline ? g_quotaTrampoline(manager) : 0;
+    PopulationTransactionScope scope(g_plugin.IsDisguiseEnabled());
     return g_quotaTrampoline ? g_quotaTrampoline(manager) : 0;
 }
 
 // Restores Bot identity while the engine applies mp_humanteam
-int64_t CS2BH_FASTCALL DetourApplyHumanTeamRestriction()
+static int64_t CS2BH_FASTCALL Detour_ApplyHumanTeamRestriction()
 {
-    if (!g_plugin.IsDisguiseEnabled()) return g_applyHumanTeamRestrictionTrampoline ? g_applyHumanTeamRestrictionTrampoline() : 0;
-    PopulationTransactionScope scope(true);
+    FunchookFlightGuard flightGuard;
+    if (!g_plugin.IsLifecycleActive()) return g_applyHumanTeamRestrictionTrampoline ? g_applyHumanTeamRestrictionTrampoline() : 0;
+    PopulationTransactionScope scope(g_plugin.IsDisguiseEnabled());
     return g_applyHumanTeamRestrictionTrampoline ? g_applyHumanTeamRestrictionTrampoline() : 0;
 }
 
 // Restores Bot identity only while the engine validates an initial team join
-int64_t CS2BH_FASTCALL DetourHandleCommandJoinTeam(void* controller, unsigned int requestedTeam, bool unknownFlag)
+static int64_t CS2BH_FASTCALL Detour_HandleCommandJoinTeam(void* controller, unsigned int requestedTeam, bool unknownFlag)
 {
-    if (!g_plugin.IsDisguiseEnabled())
+    FunchookFlightGuard flightGuard;
+    if (!g_plugin.IsLifecycleActive())
         return g_handleJoinTeamTrampoline ? g_handleJoinTeamTrampoline(controller, requestedTeam, unknownFlag) : 0;
 
     ManagedControllerTrace trace = TraceManagedController(controller);
     std::unique_ptr<PopulationTransactionScope> populationScope;
     if (trace.managed && !trace.hltv)
     {
-        populationScope = std::make_unique<PopulationTransactionScope>(true);
+        populationScope = std::make_unique<PopulationTransactionScope>(g_plugin.IsDisguiseEnabled());
     }
 
     return g_handleJoinTeamTrampoline ? g_handleJoinTeamTrampoline(controller, requestedTeam, unknownFlag) : 0;
 }
 
 // Resolves and prepares the bot quota detour
-void PrepareQuotaHook(const nlohmann::json& gamedata, const sig::ModuleInfo& serverModule)
+static void PrepareQuotaHook(const nlohmann::json& gamedata, const sig::ModuleInfo& serverModule)
 {
     if (!serverModule) return;
     std::string signature = sig::FindPlatformSig(gamedata, "CCSBotManager::MaintainBotQuota");
@@ -418,14 +470,14 @@ void PrepareQuotaHook(const nlohmann::json& gamedata, const sig::ModuleInfo& ser
         META_CONPRINTF("[BOTHIDER] warning: MaintainBotQuota sig not found — quota fix disabled\n");
         return;
     }
-    if (PrepareFunchook(g_quotaTrampoline, target, reinterpret_cast<void*>(&DetourMaintainBotQuota), "CCSBotManager::MaintainBotQuota"))
+    if (PrepareFunchook(g_quotaTrampoline, target, reinterpret_cast<void*>(&Detour_MaintainBotQuota), "CCSBotManager::MaintainBotQuota"))
     {
         g_quotaHookTarget = target;
     }
 }
 
 // Resolves and prepares the team-join identity detour
-void PrepareHandleJoinTeamHook(const nlohmann::json& gamedata, const sig::ModuleInfo& serverModule)
+static void PrepareHandleJoinTeamHook(const nlohmann::json& gamedata, const sig::ModuleInfo& serverModule)
 {
     if (!serverModule) return;
     std::string signature = sig::FindPlatformSig(gamedata, "CCSPlayerController::HandleCommand_JoinTeam");
@@ -445,7 +497,7 @@ void PrepareHandleJoinTeamHook(const nlohmann::json& gamedata, const sig::Module
     }
 
     void* target = matches.front();
-    if (PrepareFunchook(g_handleJoinTeamTrampoline, target, reinterpret_cast<void*>(&DetourHandleCommandJoinTeam),
+    if (PrepareFunchook(g_handleJoinTeamTrampoline, target, reinterpret_cast<void*>(&Detour_HandleCommandJoinTeam),
                         "CCSPlayerController::HandleCommand_JoinTeam"))
     {
         g_handleJoinTeamHookTarget = target;
@@ -453,7 +505,7 @@ void PrepareHandleJoinTeamHook(const nlohmann::json& gamedata, const sig::Module
 }
 
 // Resolves and prepares the human-team restriction detour
-void PrepareHumanTeamRestrictionHook(const nlohmann::json& gamedata, const sig::ModuleInfo& serverModule)
+static void PrepareHumanTeamRestrictionHook(const nlohmann::json& gamedata, const sig::ModuleInfo& serverModule)
 {
     if (!serverModule) return;
     std::string signature = sig::FindPlatformSig(gamedata, "MpHumanTeam_ApplyRestriction");
@@ -473,7 +525,7 @@ void PrepareHumanTeamRestrictionHook(const nlohmann::json& gamedata, const sig::
     }
 
     void* target = matches.front();
-    if (PrepareFunchook(g_applyHumanTeamRestrictionTrampoline, target, reinterpret_cast<void*>(&DetourApplyHumanTeamRestriction),
+    if (PrepareFunchook(g_applyHumanTeamRestrictionTrampoline, target, reinterpret_cast<void*>(&Detour_ApplyHumanTeamRestriction),
                         "MpHumanTeam_ApplyRestriction"))
     {
         g_applyHumanTeamRestrictionHookTarget = target;
@@ -481,7 +533,7 @@ void PrepareHumanTeamRestrictionHook(const nlohmann::json& gamedata, const sig::
 }
 
 // Resolves and prepares the entity-packing detour
-void PreparePackEntitiesHook(const nlohmann::json& gamedata)
+static void PreparePackEntitiesHook(const nlohmann::json& gamedata)
 {
     std::string signature = sig::FindPlatformSig(gamedata, "CNetworkGameServer::PackEntities");
     std::vector<uint8_t> bytes;
@@ -507,14 +559,14 @@ void PreparePackEntitiesHook(const nlohmann::json& gamedata)
     }
 
     void* target = matches.front();
-    if (PrepareFunchook(g_packEntitiesTrampoline, target, reinterpret_cast<void*>(&DetourPackEntities), "CNetworkGameServer::PackEntities"))
+    if (PrepareFunchook(g_packEntitiesTrampoline, target, reinterpret_cast<void*>(&Detour_PackEntities), "CNetworkGameServer::PackEntities"))
     {
         g_packEntitiesHookTarget = target;
     }
 }
 
 // Resolves the helper called immediately before the same-map client teardown loop
-void PrepareSameMapTeardownHook(const nlohmann::json& gamedata, const sig::ModuleInfo& serverModule)
+static void PrepareSameMapTeardownHook(const nlohmann::json& gamedata, const sig::ModuleInfo& serverModule)
 {
     if (!serverModule) return;
     constexpr const char* kTargetName = "CCSGameRules::SameMapTeardown";
@@ -543,9 +595,9 @@ void PrepareSameMapTeardownHook(const nlohmann::json& gamedata, const sig::Modul
     }
 
     auto* callSite = static_cast<unsigned char*>(matches.front()) + callOffset;
-    const auto moduleBegin = reinterpret_cast<uintptr_t>(serverModule.base);
+    const uintptr_t moduleBegin = reinterpret_cast<uintptr_t>(serverModule.base);
     const uintptr_t moduleEnd = moduleBegin + serverModule.size;
-    const auto callAddress = reinterpret_cast<uintptr_t>(callSite);
+    const uintptr_t callAddress = reinterpret_cast<uintptr_t>(callSite);
     if (callAddress < moduleBegin || callAddress > moduleEnd - 5 || callSite[0] != 0xE8)
     {
         META_CONPRINTF("[BOTHIDER] warning: same-map teardown helper call is invalid\n");
@@ -555,22 +607,20 @@ void PrepareSameMapTeardownHook(const nlohmann::json& gamedata, const sig::Modul
     int32_t displacement = 0;
     std::memcpy(&displacement, callSite + 1, sizeof(displacement));
     auto* target = callSite + 5 + displacement;
-    const auto targetAddress = reinterpret_cast<uintptr_t>(target);
+    const uintptr_t targetAddress = reinterpret_cast<uintptr_t>(target);
     if (targetAddress < moduleBegin || targetAddress >= moduleEnd)
     {
         META_CONPRINTF("[BOTHIDER] warning: same-map teardown helper target is outside server module\n");
         return;
     }
 
-    if (PrepareFunchook(g_sameMapCollectorTrampoline, target, reinterpret_cast<void*>(&DetourSameMapClientCollector),
+    if (PrepareFunchook(g_sameMapCollectorTrampoline, target, reinterpret_cast<void*>(&Detour_SameMapClientCollector),
                         "CCSGameRules::SameMapTeardown helper"))
     {
         g_sameMapTeardownHookTarget = target;
         g_sameMapTeardownReturnAddress = callSite + 5;
     }
 }
-
-} // namespace
 
 // Resolves and prepares every optional identity detour
 void PrepareAll(const nlohmann::json& gamedata, const sig::ModuleInfo& serverModule)
@@ -579,7 +629,10 @@ void PrepareAll(const nlohmann::json& gamedata, const sig::ModuleInfo& serverMod
     PrepareHandleJoinTeamHook(gamedata, serverModule);
     PrepareHumanTeamRestrictionHook(gamedata, serverModule);
     PreparePackEntitiesHook(gamedata);
-    PrepareSameMapTeardownHook(gamedata, serverModule);
+    // Same-map teardown runs while the engine is dismantling entity identities.
+    // Keep this detour disabled until its resolver and controller lifetime
+    // contract is validated on the current server build.
+    META_CONPRINTF("[BOTHIDER] same-map teardown hook disabled pending lifecycle validation\n");
 }
 
 // Installs every successfully prepared identity detour
@@ -609,11 +662,16 @@ void InstallPrepared()
 // Uninstalls all identity detours and releases their shared handle
 bool Remove()
 {
-    if (g_packEntitiesDepth != 0)
+    if (g_packEntitiesDepth != 0 || g_FunchookDepth != 0)
     {
-        META_CONPRINTF("[BOTHIDER] error: refusing funchook removal during PackEntities\n");
+        META_CONPRINTF("[BOTHIDER] error: refusing funchook removal from an active detour\n");
         return false;
     }
+
+    // The plugin lifecycle has already restored any live clients before
+    // removing hooks. Discard a leftover snapshot so its destructor cannot
+    // dereference entities from a torn-down level.
+    ResetPopulationTransaction();
 
     std::unique_lock<std::recursive_mutex> lock(g_packEntitiesMutex);
     if (!g_funchook)
@@ -633,6 +691,12 @@ bool Remove()
             return false;
         }
     }
+
+    // A thread may have entered the detour before uninstall and be waiting for
+    // the packing mutex. Keep trampoline bindings alive until that call returns.
+    lock.unlock();
+    WaitForFunchookDetours();
+    lock.lock();
 
     int result = funchook_destroy(g_funchook);
     std::string destroyMessage;

--- a/src/BotIdentity/identity_hooks.h
+++ b/src/BotIdentity/identity_hooks.h
@@ -43,6 +43,10 @@ void BeginPopulationTransaction(bool redisguise);
 void EndPopulationTransaction(bool redisguise);
 bool PopulationTransactionActive();
 
+// Drops any in-progress population snapshot without restoring through stale
+// entity pointers. Used when a level or plugin enters teardown.
+void ResetPopulationTransaction();
+
 class PopulationTransactionScope
 {
   public:

--- a/src/BotIdentity/identity_runtime.cpp
+++ b/src/BotIdentity/identity_runtime.cpp
@@ -1,21 +1,20 @@
 #include "identity_runtime.h"
 
-#include "ISmmPlugin.h"
 #include "bot_info.h"
 #include "entity_access.h"
 #include "fake_client_manager.h"
 #include "identity_hooks.h"
 #include "identity_state.h"
 #include "personas.h"
+#include "plugin.h"
 #include "serversideclient_ref.h"
 #include "version_targets.h"
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cstdint>
 #include <cstring>
-#include <string>
-#include <utility>
 #include <vector>
 
 #include <entity2/entityinstance.h>
@@ -26,10 +25,8 @@ extern INetworkServerService* g_pNetworkServerService;
 
 namespace cs2bh {
 
-namespace {
-
 // Returns whether a SteamID is used by another connected client
-bool IsSteamIdInUseByOther(uint64_t steamId, int exceptSlot)
+static bool IsSteamIdInUseByOther(uint64_t steamId, int exceptSlot)
 {
     if (steamId == 0 || !g_pNetworkServerService) return false;
     auto* gameServer = g_pNetworkServerService->GetIGameServer();
@@ -50,7 +47,7 @@ bool IsSteamIdInUseByOther(uint64_t steamId, int exceptSlot)
 }
 
 // Generates a random value for SteamID pool selection
-uint64_t NextSteamIdRandom()
+static uint64_t NextSteamIdRandom()
 {
     static uint64_t state = static_cast<uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count()) | 1ULL;
     uint64_t x = state;
@@ -62,7 +59,7 @@ uint64_t NextSteamIdRandom()
 }
 
 // Resolves the current pawn for one managed bot slot
-BotPawnRef ResolveManagedBotPawn(int slot)
+static BotPawnRef ResolveManagedBotPawn(int slot)
 {
     BotPawnRef result;
     const int pawnHandleOffset = entity_access::BotPawnHandleOffset();
@@ -87,7 +84,7 @@ BotPawnRef ResolveManagedBotPawn(int slot)
     if (!pawn || entity_access::IsEntityBeingDeleted(pawn)) return result;
 
     auto* pawnEntity = reinterpret_cast<CEntityInstance*>(pawn);
-    if (std::cmp_not_equal(static_cast<uint32_t>(pawnEntity->GetRefEHandle().ToInt()), pawnHandle))
+    if (static_cast<uint32_t>(pawnEntity->GetRefEHandle().ToInt()) != pawnHandle)
     {
         return result;
     }
@@ -98,7 +95,7 @@ BotPawnRef ResolveManagedBotPawn(int slot)
 }
 
 // Collects every unique pawn currently owned by managed bots
-std::vector<BotPawnRef> CollectManagedBotPawns()
+static std::vector<BotPawnRef> CollectManagedBotPawns()
 {
     std::vector<BotPawnRef> pawns;
     pawns.reserve(PersonaPool::kMaxSlots);
@@ -106,7 +103,7 @@ std::vector<BotPawnRef> CollectManagedBotPawns()
     {
         BotPawnRef pawn = ResolveManagedBotPawn(slot);
         if (!pawn.instance) continue;
-        auto duplicate = std::ranges::find_if(pawns, [&pawn](const BotPawnRef& existing) {
+        auto duplicate = std::find_if(pawns.begin(), pawns.end(), [&pawn](const BotPawnRef& existing) {
             return existing.instance == pawn.instance;
         });
         if (duplicate == pawns.end()) pawns.push_back(pawn);
@@ -115,7 +112,7 @@ std::vector<BotPawnRef> CollectManagedBotPawns()
 }
 
 // Checks whether a current client still references one controller
-bool IsControllerReferencedByClient(void* controller, uint16_t* userIdOut)
+static bool IsControllerReferencedByClient(void* controller, uint16_t* userIdOut)
 {
     for (int slot = 0; slot < PersonaPool::kMaxSlots; ++slot)
     {
@@ -137,8 +134,6 @@ bool IsControllerReferencedByClient(void* controller, uint16_t* userIdOut)
     }
     return false;
 }
-
-} // namespace
 
 // Collects controller and client state for a managed team join
 ManagedControllerTrace TraceManagedController(void* controller)
@@ -207,7 +202,7 @@ void RestoreBotFlagOverride(const std::vector<BotPawnRef>& pawns)
         }
 
         auto* currentEntity = reinterpret_cast<CEntityInstance*>(currentPawn);
-        if (std::cmp_not_equal(static_cast<uint32_t>(currentEntity->GetRefEHandle().ToInt()), pawn.handle))
+        if (static_cast<uint32_t>(currentEntity->GetRefEHandle().ToInt()) != pawn.handle)
         {
             continue;
         }
@@ -222,7 +217,7 @@ namespace identity_runtime {
 // Counts connected human clients, excluding managed/fake/HLTV clients
 int CountHumanClients()
 {
-    if (!g_pNetworkServerService) return 0;
+    if (!g_plugin.IsLifecycleActive() || !g_pNetworkServerService) return 0;
     auto* gameServer = g_pNetworkServerService->GetIGameServer();
     if (!gameServer) return 0;
     auto* clients = reinterpret_cast<CUtlVector<void*>*>(reinterpret_cast<unsigned char*>(gameServer) + targets::g_clientListOffset);
@@ -243,6 +238,7 @@ int CountHumanClients()
 
 void ApplyManagedDisguise(bool disguised)
 {
+    if (!g_plugin.IsLifecycleActive()) return;
     for (int slot = 0; slot < PersonaPool::kMaxSlots; ++slot)
     {
         if (!Manager().IsManaged(slot)) continue;
@@ -282,7 +278,7 @@ uint64_t MakeUniqueSteamId(int slot, uint64_t desired)
     for (const BotEntry& entry : BotInfo().All())
     {
         if (entry.steamId64 == 0 || IsSteamIdInUseByOther(entry.steamId64, slot) ||
-            std::ranges::find(available, entry.steamId64) != available.end())
+            std::find(available.begin(), available.end(), entry.steamId64) != available.end())
         {
             continue;
         }
@@ -303,17 +299,22 @@ uint64_t MakeUniqueSteamId(int slot, uint64_t desired)
 // Synchronizes the controller fake-client bit for one slot
 bool SetControllerFakeClientFlag(int slot, bool fakeClient)
 {
-    if (targets::g_controllerFakeClientFlagsOffset < 0) return false;
+    if ((!g_plugin.IsLifecycleActive() && !g_plugin.IsLifecycleRestorationActive()) ||
+        targets::g_controllerFakeClientFlagsOffset < 0)
+        return false;
     void* client = entity_access::ResolveClientBySlot(slot);
     if (!client) return false;
 
     const int entityIndex = *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(client) + ssc::g_entityIndexOffset);
     char className[64];
     void* controller = entity_access::ResolveEntityInstance(entityIndex, className, sizeof(className));
-    if (!controller || std::strcmp(className, "cs_player_controller") != 0)
+    if (!controller || std::strcmp(className, "cs_player_controller") != 0 || entity_access::IsEntityBeingDeleted(controller))
     {
         return false;
     }
+
+    const uint32_t handle = static_cast<uint32_t>(reinterpret_cast<CEntityInstance*>(controller)->GetRefEHandle().ToInt());
+    if ((handle & 0x7FFFu) != static_cast<uint32_t>(entityIndex)) return false;
 
     constexpr uint32_t kFakeClientBit = 0x100;
     auto* flags = reinterpret_cast<uint32_t*>(reinterpret_cast<unsigned char*>(controller) + targets::g_controllerFakeClientFlagsOffset);
@@ -331,6 +332,7 @@ bool SetControllerFakeClientFlag(int slot, bool fakeClient)
 // Restores native identity for managed bots before engine-owned teardown
 int RestoreManagedClientsForEngineTeardown()
 {
+    if (!g_plugin.IsLifecycleActive() && !g_plugin.IsLifecycleRestorationActive()) return 0;
     int restored = 0;
     for (int slot = 0; slot < PersonaPool::kMaxSlots; ++slot)
     {
@@ -338,9 +340,19 @@ int RestoreManagedClientsForEngineTeardown()
         void* client = entity_access::ResolveClientBySlot(slot);
         if (!client) continue;
 
+        const int entityIndex = *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(client) + ssc::g_entityIndexOffset);
+        char className[64];
+        void* controller = entity_access::ResolveEntityInstance(entityIndex, className, sizeof(className));
+        if (!controller || std::strcmp(className, "cs_player_controller") != 0 || entity_access::IsEntityBeingDeleted(controller))
+            continue;
+
+        const uint32_t handle = static_cast<uint32_t>(reinterpret_cast<CEntityInstance*>(controller)->GetRefEHandle().ToInt());
+        if ((handle & 0x7FFFu) != static_cast<uint32_t>(entityIndex)) continue;
+        if (!SetControllerFakeClientFlag(slot, true)) continue;
+
         ssc::SetFakePlayer(client);
-        SetControllerFakeClientFlag(slot, true);
         ssc::WriteSteamId(client, 0);
+        META_CONPRINTF("[BOTHIDER] teardown restore slot=%d entIdx=%d handle=0x%08x state=teardown\n", slot, entityIndex, handle);
         ++restored;
     }
     return restored;
@@ -349,7 +361,7 @@ int RestoreManagedClientsForEngineTeardown()
 // Queues one client controller for identity-checked removal
 bool QueueControllerRemovalForClient(void* client, int slot)
 {
-    if (!client) return false;
+    if (!g_plugin.IsLifecycleActive() || !client) return false;
     if (!entity_access::UtilRemoveTarget())
     {
         META_CONPRINTF("[BOTHIDER] deferred destroy unavailable: UTIL_Remove unresolved\n");
@@ -377,13 +389,13 @@ bool QueueControllerRemovalForClient(void* client, int slot)
 
     const uint32_t handle = static_cast<uint32_t>(reinterpret_cast<CEntityInstance*>(controller)->GetRefEHandle().ToInt());
     auto& pending = identity_state::PendingControllerRemovals();
-    auto duplicate = std::ranges::find_if(pending, [handle](const identity_state::PendingControllerRemoval& item) {
+    auto duplicate = std::find_if(pending.begin(), pending.end(), [handle](const identity_state::PendingControllerRemoval& item) {
         return item.handle == handle;
     });
     if (duplicate != pending.end()) return true;
 
     const uint16_t userId = *reinterpret_cast<uint16_t*>(reinterpret_cast<unsigned char*>(client) + ssc::g_userIdOffset);
-    pending.push_back({ .controller = controller, .handle = handle, .slot = slot, .userId = userId, .referencedFrames = 0 });
+    pending.push_back({ controller, handle, slot, userId, 0 });
     return true;
 }
 
@@ -391,6 +403,11 @@ bool QueueControllerRemovalForClient(void* client, int slot)
 void DrainPendingControllerRemovals()
 {
     auto& pending = identity_state::PendingControllerRemovals();
+    if (!g_plugin.IsLifecycleActive())
+    {
+        pending.clear();
+        return;
+    }
     if (!entity_access::UtilRemoveTarget())
     {
         pending.clear();
@@ -404,7 +421,7 @@ void DrainPendingControllerRemovals()
         void* current = entity_access::ResolveEntityInstance(entityIndex, className, sizeof(className));
         if (current != item->controller || std::strcmp(className, "cs_player_controller") != 0 ||
             entity_access::IsEntityBeingDeleted(current) ||
-            std::cmp_not_equal(static_cast<uint32_t>(reinterpret_cast<CEntityInstance*>(current)->GetRefEHandle().ToInt()), item->handle))
+            static_cast<uint32_t>(reinterpret_cast<CEntityInstance*>(current)->GetRefEHandle().ToInt()) != item->handle)
         {
             item = pending.erase(item);
             continue;

--- a/src/common/entity_access.cpp
+++ b/src/common/entity_access.cpp
@@ -1,13 +1,8 @@
 #include "entity_access.h"
 
-#include "playerslot.h"
-#include "nlohmann/json.hpp"
-#include "ISmmPlugin.h"
-#include "entityidentity.h"
-#include "plugin.h" // NOLINT(misc-include-cleaner)
+#include "plugin.h"
 #include "schema_resolver.h"
 #include "serversideclient_ref.h"
-#include "sig_scan.h"
 #include "version_targets.h"
 
 #include <cstdint>
@@ -15,12 +10,13 @@
 #include <string>
 #include <vector>
 
+#include <eiface.h>
 #include <entity2/entityinstance.h>
 #include <iserver.h>
 #include <tier1/utlvector.h>
 
-#ifdef _WIN32
-#include <excpt.h>
+#if defined(_WIN32)
+#include <Windows.h>
 #define CS2BH_FASTCALL __fastcall
 #else
 #define CS2BH_FASTCALL
@@ -30,28 +26,26 @@ extern INetworkServerService* g_pNetworkServerService;
 
 namespace cs2bh::entity_access {
 
-namespace {
-
 using UtilRemoveFn = void(CS2BH_FASTCALL*)(void*);
 using ClientSetNameFn = void(CS2BH_FASTCALL*)(void*, const char*);
 
-void* g_gameResourceService = nullptr;
-UtilRemoveFn g_utilRemove = nullptr;
-void** g_entitySystemGlobal = nullptr;
-int g_botPawnHandleOffset = -1;
-
-} // namespace
+static void* g_pGameResourceService = nullptr;
+static UtilRemoveFn g_pfnUtilRemove = nullptr;
+static void** g_ppEntSysGlobal = nullptr;
+static int g_botPawnHandleOffset = -1;
 
 // Stores the GameResourceService interface used for entity resolution
-void SetGameResourceService(void* gameResourceService) { g_gameResourceService = gameResourceService; }
+void SetGameResourceService(void* gameResourceService) { g_pGameResourceService = gameResourceService; }
 
 // Returns the current GameResourceService interface
-void* GameResourceService() { return g_gameResourceService; }
+void* GameResourceService() { return g_pGameResourceService; }
 
 // Resolves one server-side client from its slot
 void* ResolveClientBySlot(int slot)
 {
-    if (!g_pNetworkServerService || targets::g_clientListOffset < 0) return nullptr;
+    if ((!g_plugin.IsLifecycleActive() && !g_plugin.IsLifecycleRestorationActive()) || !g_pNetworkServerService ||
+        targets::g_clientListOffset < 0)
+        return nullptr;
     auto* gameServer = g_pNetworkServerService->GetIGameServer();
     if (!gameServer) return nullptr;
     auto* clients = reinterpret_cast<CUtlVector<void*>*>(reinterpret_cast<unsigned char*>(gameServer) + targets::g_clientListOffset);
@@ -63,7 +57,7 @@ void* ResolveClientBySlot(int slot)
 // Publishes changed userinfo for one client slot
 bool RefreshClientUserInfo(int slot)
 {
-    if (!g_pNetworkServerService || slot < 0 || slot >= 64) return false;
+    if (!g_plugin.IsLifecycleActive() || !g_pNetworkServerService || slot < 0 || slot >= 64) return false;
     auto* gameServer = g_pNetworkServerService->GetIGameServer();
     if (!gameServer) return false;
     gameServer->UserInfoChanged(CPlayerSlot(slot));
@@ -73,8 +67,8 @@ bool RefreshClientUserInfo(int slot)
 // Resolves UTIL_Remove and its entity-system reference
 void ResolveUtilRemoveAndEntSys(const nlohmann::json& gamedata, const sig::ModuleInfo& serverModule)
 {
-    g_utilRemove = nullptr;
-    g_entitySystemGlobal = nullptr;
+    g_pfnUtilRemove = nullptr;
+    g_ppEntSysGlobal = nullptr;
     if (!serverModule)
     {
         META_CONPRINTF("[BOTHIDER] warning: %s module unresolved for signature scan\n", targets::kServerModuleName);
@@ -92,7 +86,7 @@ void ResolveUtilRemoveAndEntSys(const nlohmann::json& gamedata, const sig::Modul
 
     auto* hit = static_cast<unsigned char*>(sig::FindPatternIn(serverModule, bytes, wildcards));
     if (!hit) return;
-    g_utilRemove = reinterpret_cast<UtilRemoveFn>(hit);
+    g_pfnUtilRemove = reinterpret_cast<UtilRemoveFn>(hit);
 
     /*
      * Windows: mov rcx, [rip+disp32]
@@ -107,7 +101,7 @@ void ResolveUtilRemoveAndEntSys(const nlohmann::json& gamedata, const sig::Modul
         unsigned char* displacementAddress = hit + i + 3;
         const int32_t displacement = *reinterpret_cast<int32_t*>(displacementAddress);
         unsigned char* instructionEnd = displacementAddress + 4;
-        g_entitySystemGlobal = reinterpret_cast<void**>(instructionEnd + displacement);
+        g_ppEntSysGlobal = reinterpret_cast<void**>(instructionEnd + displacement);
         break;
     }
 }
@@ -149,12 +143,11 @@ void LoadMemberOffsets(const nlohmann::json& gamedata)
         FindPlatformOffset(gamedata, "CEntityIdentity::m_designerName", targets::g_entityIdentityClassNameOffset);
 }
 
-namespace {
-
-// Reads one pointer while isolating invalid memory access on Windows
-bool SafeReadPointer(const void* address, void** output)
+// Reads one engine pointer. Windows can catch access faults; Linux still
+// relies on the engine lifecycle guard and validated entity handles.
+static bool ReadEnginePointer(const void* address, void** output)
 {
-#ifdef _WIN32
+#if defined(_WIN32)
     __try
     {
         *output = *reinterpret_cast<void* const*>(address);
@@ -176,10 +169,11 @@ bool SafeReadPointer(const void* address, void** output)
 #endif
 }
 
-// Copies one indirectly referenced string with guarded reads on Windows
-bool SafeReadString(const void* address, char* output, size_t capacity)
+// Copies one engine string. Linux cannot make a raw pointer dereference safe
+// against a concurrent use-after-free.
+static bool ReadEngineString(const void* address, char* output, size_t capacity)
 {
-#ifdef _WIN32
+#if defined(_WIN32)
     __try
     {
         const char* source = *reinterpret_cast<const char* const*>(address);
@@ -219,22 +213,20 @@ bool SafeReadString(const void* address, char* output, size_t capacity)
 #endif
 }
 
-} // namespace
-
 // Resolves one entity instance and optionally copies its class name
 void* ResolveEntityInstance(int entityIndex, char* classnameOut, size_t classnameCap)
 {
     if (classnameOut && classnameCap) classnameOut[0] = '\0';
-    if (!g_gameResourceService || entityIndex <= 0 || entityIndex >= 0x8000 || targets::g_entitySystemOffsetInGameResourceService < 0 ||
-        targets::g_entitySystemIdentityChunksOffset < 0 || targets::g_entityIdentitySize <= 0 ||
-        targets::g_entityIdentityInstanceOffset < 0 || (classnameOut && classnameCap && targets::g_entityIdentityClassNameOffset < 0))
+    if ((!g_plugin.IsLifecycleActive() && !g_plugin.IsLifecycleRestorationActive()) || !g_pGameResourceService || entityIndex <= 0 ||
+        entityIndex >= 0x8000 || targets::g_entitySystemOffsetInGameResourceService < 0 ||
+        targets::g_entitySystemIdentityChunksOffset < 0 || targets::g_entityIdentitySize <= 0 || targets::g_entityIdentityInstanceOffset < 0 ||
+        (classnameOut && classnameCap && targets::g_entityIdentityClassNameOffset < 0))
     {
         return nullptr;
     }
 
     void* entitySystem = nullptr;
-    if (!SafeReadPointer(reinterpret_cast<unsigned char*>(g_gameResourceService) + targets::g_entitySystemOffsetInGameResourceService,
-                         &entitySystem) ||
+    if (!ReadEnginePointer(reinterpret_cast<unsigned char*>(g_pGameResourceService) + targets::g_entitySystemOffsetInGameResourceService, &entitySystem) ||
         !entitySystem)
     {
         return nullptr;
@@ -242,18 +234,18 @@ void* ResolveEntityInstance(int entityIndex, char* classnameOut, size_t classnam
 
     void* chunk = nullptr;
     const void* chunkSlot = reinterpret_cast<unsigned char*>(entitySystem) + targets::g_entitySystemIdentityChunksOffset +
-                            ((entityIndex / targets::kEntListChunkSize) * sizeof(void*));
-    if (!SafeReadPointer(chunkSlot, &chunk) || !chunk) return nullptr;
+                            (entityIndex / targets::kEntListChunkSize) * sizeof(void*);
+    if (!ReadEnginePointer(chunkSlot, &chunk) || !chunk) return nullptr;
 
     unsigned char* identity =
-        reinterpret_cast<unsigned char*>(chunk) + ((entityIndex % targets::kEntListChunkSize) * targets::g_entityIdentitySize);
+        reinterpret_cast<unsigned char*>(chunk) + (entityIndex % targets::kEntListChunkSize) * targets::g_entityIdentitySize;
     if (classnameOut && classnameCap)
     {
-        SafeReadString(identity + targets::g_entityIdentityClassNameOffset, classnameOut, classnameCap);
+        ReadEngineString(identity + targets::g_entityIdentityClassNameOffset, classnameOut, classnameCap);
     }
 
     void* instance = nullptr;
-    if (!SafeReadPointer(identity + targets::g_entityIdentityInstanceOffset, &instance) || !instance)
+    if (!ReadEnginePointer(identity + targets::g_entityIdentityInstanceOffset, &instance) || !instance)
     {
         return nullptr;
     }
@@ -263,32 +255,32 @@ void* ResolveEntityInstance(int entityIndex, char* classnameOut, size_t classnam
 // Returns whether an entity is already entering deletion
 bool IsEntityBeingDeleted(void* instance)
 {
-    if (!instance) return true;
+    if ((!g_plugin.IsLifecycleActive() && !g_plugin.IsLifecycleRestorationActive()) || !instance) return true;
     auto* entity = reinterpret_cast<CEntityInstance*>(instance);
     if (!entity->m_pEntity) return true;
-    const auto flags = static_cast<uint32_t>(entity->m_pEntity->m_flags);
+    const uint32_t flags = static_cast<uint32_t>(entity->m_pEntity->m_flags);
     return (flags & (EF_DELETE_IN_PROGRESS | EF_MARKED_FOR_DELETE)) != 0;
 }
 
 // Marks one flattened entity field as changed
 void MarkEntityFieldChanged(void* instance, unsigned int offset)
 {
-    if (!instance) return;
+    if ((!g_plugin.IsLifecycleActive() && !g_plugin.IsLifecycleRestorationActive()) || !instance) return;
     NetworkStateChangedData changed(offset);
     reinterpret_cast<CEntityInstance*>(instance)->NetworkStateChanged(changed);
 }
 
 // Returns the resolved UTIL_Remove target
-void* UtilRemoveTarget() { return reinterpret_cast<void*>(g_utilRemove); }
+void* UtilRemoveTarget() { return reinterpret_cast<void*>(g_pfnUtilRemove); }
 
 // Returns the resolved entity-system global address
-void* EntitySystemGlobalAddress() { return reinterpret_cast<void*>(g_entitySystemGlobal); }
+void* EntitySystemGlobalAddress() { return reinterpret_cast<void*>(g_ppEntSysGlobal); }
 
 // Removes one entity through the resolved engine function
 bool RemoveEntity(void* instance)
 {
-    if (!g_utilRemove || !instance) return false;
-    g_utilRemove(instance);
+    if (!g_plugin.IsLifecycleActive() || !g_pfnUtilRemove || !instance) return false;
+    g_pfnUtilRemove(instance);
     return true;
 }
 
@@ -301,7 +293,7 @@ int BotPawnHandleOffset() { return g_botPawnHandleOffset; }
 // Resets the idle timer for the pawn owned by one client
 void ResetIdleTimerForClient(void* client)
 {
-    if (!client) return;
+    if (!g_plugin.IsLifecycleActive() || !client) return;
 
     const int pawnOffset = schema::GetFieldOffset("CBasePlayerController", "m_hPawn");
     const int idleOffset = schema::GetFieldOffset("CCSPlayerPawnBase", "m_flIdleTimeSinceLastAction");
@@ -321,17 +313,17 @@ void ResetIdleTimerForClient(void* client)
     void* pawn = ResolveEntityInstance(pawnIndex, nullptr, 0);
     if (!pawn) return;
 
-    *reinterpret_cast<float*>(reinterpret_cast<unsigned char*>(pawn) + idleOffset) = 0.0F;
+    *reinterpret_cast<float*>(reinterpret_cast<unsigned char*>(pawn) + idleOffset) = 0.0f;
 }
 
 // Updates the engine-side name for one client
 const char* SetEngineName(void* client, const char* newName)
 {
-    if (!client || !newName || !newName[0] || targets::g_vtableSlotClientSetName < 0)
+    if (!g_plugin.IsLifecycleActive() || !client || !newName || !newName[0] || targets::g_vtableSlotClientSetName < 0)
     {
         return nullptr;
     }
-#ifdef _WIN32
+#if defined(_WIN32)
     __try
     {
         auto** vtable = *reinterpret_cast<void***>(client);
@@ -358,9 +350,9 @@ const char* SetEngineName(void* client, const char* newName)
 // Clears resolved interfaces and runtime targets
 void Reset()
 {
-    g_gameResourceService = nullptr;
-    g_utilRemove = nullptr;
-    g_entitySystemGlobal = nullptr;
+    g_pGameResourceService = nullptr;
+    g_pfnUtilRemove = nullptr;
+    g_ppEntSysGlobal = nullptr;
     g_botPawnHandleOffset = -1;
 }
 

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -43,83 +43,84 @@
 #include <tier1/utlvector.h>
 #include <tier1/convar.h>
 
-SH_DECL_HOOK6_void(
-    IServerGameClients,
-    OnClientConnected,
-    SH_NOATTRIB,
-    0,
-    CPlayerSlot,
-    const char*,
-    uint64,
-    const char*,
-    const char*,
-    bool); // NOLINT(google-build-using-namespace,google-explicit-constructor,misc-use-internal-linkage,performance-unnecessary-value-param,bugprone-multi-level-implicit-pointer-conversion)
-SH_DECL_HOOK4_void(
-    IServerGameClients,
-    ClientPutInServer,
-    SH_NOATTRIB,
-    0,
-    CPlayerSlot,
-    char const*,
-    int,
-    uint64); // NOLINT(google-build-using-namespace,google-explicit-constructor,misc-use-internal-linkage,performance-unnecessary-value-param,bugprone-multi-level-implicit-pointer-conversion)
-SH_DECL_HOOK5_void( // NOLINT(google-build-using-namespace,google-explicit-constructor,misc-use-internal-linkage,performance-unnecessary-value-param,bugprone-multi-level-implicit-pointer-conversion)
-    IServerGameClients,
-    ClientDisconnect,
-    SH_NOATTRIB,
-    0,
-    CPlayerSlot,
-    ENetworkDisconnectionReason,
-    const char*,
-    uint64,
-    const char*);
-SH_DECL_HOOK3(
-    INetworkGameServer,
-    StartChangeLevel,
-    SH_NOATTRIB,
-    0,
-    CUtlVector<INetworkGameClient*>*,
-    const char*,
-    const char*,
-    void*); // NOLINT(google-build-using-namespace,google-explicit-constructor,misc-use-internal-linkage,performance-unnecessary-value-param,bugprone-multi-level-implicit-pointer-conversion)
-SH_DECL_HOOK3_void(
-    IServerGameDLL,
-    GameFrame,
-    SH_NOATTRIB,
-    0,
-    bool,
-    bool,
-    bool); // NOLINT(google-build-using-namespace,google-explicit-constructor,misc-use-internal-linkage,performance-unnecessary-value-param,bugprone-multi-level-implicit-pointer-conversion)
-SH_DECL_HOOK3_void(
-    ICvar,
-    DispatchConCommand,
-    SH_NOATTRIB,
-    0,
-    ConCommandRef,
-    const CCommandContext&,
-    const CCommand&); // NOLINT(google-build-using-namespace,google-explicit-constructor,misc-use-internal-linkage,performance-unnecessary-value-param,bugprone-multi-level-implicit-pointer-conversion)
+SH_DECL_HOOK6_void(IServerGameClients, OnClientConnected, SH_NOATTRIB, 0, CPlayerSlot, const char*, uint64, const char*, const char*, bool);
+SH_DECL_HOOK4_void(IServerGameClients, ClientPutInServer, SH_NOATTRIB, 0, CPlayerSlot, char const*, int, uint64);
+SH_DECL_HOOK5_void(
+    IServerGameClients, ClientDisconnect, SH_NOATTRIB, 0, CPlayerSlot, ENetworkDisconnectionReason, const char*, uint64, const char*);
+SH_DECL_HOOK3(INetworkGameServer, StartChangeLevel, SH_NOATTRIB, 0, CUtlVector<INetworkGameClient*>*, const char*, const char*, void*);
+SH_DECL_HOOK3_void(IServerGameDLL, GameFrame, SH_NOATTRIB, 0, bool, bool, bool);
+SH_DECL_HOOK3_void(ICvar, DispatchConCommand, SH_NOATTRIB, 0, ConCommandRef, const CCommandContext&, const CCommand&);
 
 namespace cs2bh {
 
 HiderPlugin g_plugin;
 
+void HiderPlugin::SetLifecycleActive()
+{
+    std::unique_lock<std::mutex> lock(m_LifecycleMutex);
+    m_LifecycleCv.wait(lock, [this] {
+        return !m_TeardownRestoreActive.load(std::memory_order_acquire);
+    });
+
+    // A new level starts with no valid transaction snapshot from the previous
+    // level. Discard it before allowing hooks to access current entities.
+    identity_hooks::ResetPopulationTransaction();
+    m_populationCommandDepth = 0;
+    m_tickCounter = 0;
+    m_TeardownRestoreActive.store(false, std::memory_order_release);
+    m_LifecycleState.store(LifecycleState::Active, std::memory_order_release);
+    lock.unlock();
+    META_CONPRINTF("[BOTHIDER] lifecycle state=active\n");
+}
+
+bool HiderPlugin::BeginLifecycleTeardown()
+{
+    std::unique_lock<std::mutex> lock(m_LifecycleMutex);
+    if (m_LifecycleState.load(std::memory_order_acquire) != LifecycleState::Active)
+    {
+        m_LifecycleCv.wait(lock, [this] {
+            return !m_TeardownRestoreActive.load(std::memory_order_acquire);
+        });
+        return false;
+    }
+
+    // Publish teardown before restoring anything. Ordinary hooks use
+    // IsLifecycleActive() and stop touching level-owned objects immediately.
+    m_LifecycleState.store(LifecycleState::Teardown, std::memory_order_release);
+    m_TeardownRestoreActive.store(true, std::memory_order_release);
+    return true;
+}
+
+void HiderPlugin::EndLifecycleTeardown()
+{
+    m_populationCommandDepth = 0;
+    identity_runtime::ClearPendingControllerRemovals();
+    identity_hooks::ResetPopulationTransaction();
+    {
+        std::lock_guard<std::mutex> lock(m_LifecycleMutex);
+        m_TeardownRestoreActive.store(false, std::memory_order_release);
+    }
+    m_LifecycleCv.notify_all();
+}
+
 } // namespace cs2bh
 
-PLUGIN_EXPOSE(cs2bh::HiderPlugin, cs2bh::g_plugin); // NOLINT(misc-use-anonymous-namespace,bugprone-throwing-static-initialization)
+PLUGIN_EXPOSE(cs2bh::HiderPlugin, cs2bh::g_plugin);
 
 // Interface globals
 
-IVEngineServer* g_engine = nullptr; // NOLINT(misc-use-internal-linkage)
-ICvar* g_icvar = nullptr; // NOLINT(misc-use-internal-linkage)
-IServerGameClients* g_gameclients = nullptr; // NOLINT(misc-use-internal-linkage)
-IServerGameDLL* g_server = nullptr; // NOLINT(misc-use-internal-linkage)
+IVEngineServer* engine = nullptr;
+ICvar* icvar = nullptr;
+IServerGameClients* gameclients = nullptr;
+IServerGameDLL* server = nullptr;
 extern INetworkServerService* g_pNetworkServerService;
 
 namespace cs2bh {
 
 // Attaches level-scoped hooks and resets transient runtime state
-void HiderPlugin::OnLevelInit(char const* mapName, char const*, char const*, char const*, bool, bool)
+void HiderPlugin::OnLevelInit(char const* pMapName, char const*, char const*, char const*, bool, bool)
 {
+    SetLifecycleActive();
     identity_runtime::ClearPendingControllerRemovals();
     avatar::ResetRuntime();
     auto* gameServer = g_pNetworkServerService ? g_pNetworkServerService->GetIGameServer() : nullptr;
@@ -136,18 +137,33 @@ void HiderPlugin::OnLevelInit(char const* mapName, char const*, char const*, cha
         META_CONPRINTF("[BOTHIDER] StartChangeLevel hook attached to %p (id %d)\n", static_cast<void*>(gameServer),
                        m_startChangeLevelHookId);
     }
-    META_CONPRINTF("[BOTHIDER] OnLevelInit map=%s\n", mapName ? mapName : "?");
+    META_CONPRINTF("[BOTHIDER] OnLevelInit map=%s\n", pMapName ? pMapName : "?");
 }
 
 // Releases all state owned by the current level
 void HiderPlugin::OnLevelShutdown()
 {
+    const bool restoreOwner = BeginLifecycleTeardown();
+    int restoredClients = 0;
+    if (restoreOwner)
+    {
+        // Restore only through the dedicated teardown window. Ordinary hooks
+        // are already blocked by the state transition above.
+        restoredClients = identity_runtime::RestoreManagedClientsForEngineTeardown();
+        EndLifecycleTeardown();
+    }
     identity_state::ClearAll();
     Manager().ReleaseAll();
-    avatar::ProcessOverrides();
+    identity_runtime::ClearPendingControllerRemovals();
     avatar::ResetRuntime();
     BotInfo().ResetAssignments();
-    META_CONPRINTF("[BOTHIDER] OnLevelShutdown — state drained\n");
+    if (m_startChangeLevelHookId != 0)
+    {
+        SH_REMOVE_HOOK_ID(m_startChangeLevelHookId);
+        m_startChangeLevelHookId = 0;
+    }
+    m_hookedGameServer = nullptr;
+    META_CONPRINTF("[BOTHIDER] OnLevelShutdown restored=%d — state drained\n", restoredClients);
 }
 
 // Resolves interfaces and installs every plugin module
@@ -160,11 +176,14 @@ bool HiderPlugin::Load(PluginId id, ISmmAPI* ismm, char* error, size_t maxlen, b
     m_fakePingEnabled = true;
     m_fakePingMin = 20;
     m_fakePingMax = 90;
+    m_LifecycleState.store(LifecycleState::Inactive, std::memory_order_release);
+    m_populationCommandDepth = 0;
+    identity_hooks::ResetPopulationTransaction();
 
-    GET_V_IFACE_CURRENT(GetEngineFactory, g_engine, IVEngineServer, INTERFACEVERSION_VENGINESERVER);
-    GET_V_IFACE_CURRENT(GetEngineFactory, g_icvar, ICvar, CVAR_INTERFACE_VERSION);
-    GET_V_IFACE_ANY(GetServerFactory, g_gameclients, IServerGameClients, INTERFACEVERSION_SERVERGAMECLIENTS);
-    GET_V_IFACE_ANY(GetServerFactory, g_server, IServerGameDLL, INTERFACEVERSION_SERVERGAMEDLL);
+    GET_V_IFACE_CURRENT(GetEngineFactory, engine, IVEngineServer, INTERFACEVERSION_VENGINESERVER);
+    GET_V_IFACE_CURRENT(GetEngineFactory, icvar, ICvar, CVAR_INTERFACE_VERSION);
+    GET_V_IFACE_ANY(GetServerFactory, gameclients, IServerGameClients, INTERFACEVERSION_SERVERGAMECLIENTS);
+    GET_V_IFACE_ANY(GetServerFactory, server, IServerGameDLL, INTERFACEVERSION_SERVERGAMEDLL);
     GET_V_IFACE_ANY(GetEngineFactory, g_pNetworkServerService, INetworkServerService, NETWORKSERVERSERVICE_INTERFACE_VERSION);
 
     // Reads startup identity and fake-ping settings
@@ -275,7 +294,7 @@ bool HiderPlugin::Load(PluginId id, ISmmAPI* ismm, char* error, size_t maxlen, b
                                "name overwrite disabled\n");
             }
 
-            sig::ModuleInfo serverModule = sig::ModuleFromInterfacePtr(g_gameclients);
+            sig::ModuleInfo serverModule = sig::ModuleFromInterfacePtr(gameclients);
             if (!serverModule) serverModule = sig::ModuleFromName(targets::kServerModuleName);
             entity_access::ResolveUtilRemoveAndEntSys(gamedata, serverModule);
 
@@ -288,7 +307,7 @@ bool HiderPlugin::Load(PluginId id, ISmmAPI* ismm, char* error, size_t maxlen, b
                        "controller cleanup disabled\n");
     }
 
-    g_pCVar = g_icvar;
+    g_pCVar = icvar;
     g_SMAPI->AddListener(this, this);
 
     // Resolve controller pawn and idle-timer schema offsets
@@ -339,12 +358,12 @@ bool HiderPlugin::Load(PluginId id, ISmmAPI* ismm, char* error, size_t maxlen, b
                        jsonPath.c_str());
     }
 
-    SH_ADD_HOOK(IServerGameClients, OnClientConnected, g_gameclients, SH_MEMBER(this, &HiderPlugin::HookOnClientConnectedPost), true);
-    SH_ADD_HOOK(IServerGameClients, ClientPutInServer, g_gameclients, SH_MEMBER(this, &HiderPlugin::HookClientPutInServerPost), true);
-    SH_ADD_HOOK(IServerGameClients, ClientDisconnect, g_gameclients, SH_MEMBER(this, &HiderPlugin::HookClientDisconnectPre), false);
-    SH_ADD_HOOK(IServerGameDLL, GameFrame, g_server, SH_MEMBER(this, &HiderPlugin::HookGameFramePost), true);
-    SH_ADD_HOOK(ICvar, DispatchConCommand, g_icvar, SH_MEMBER(this, &HiderPlugin::HookDispatchConCommandPre), false);
-    SH_ADD_HOOK(ICvar, DispatchConCommand, g_icvar, SH_MEMBER(this, &HiderPlugin::HookDispatchConCommandPost), true);
+    SH_ADD_HOOK(IServerGameClients, OnClientConnected, gameclients, SH_MEMBER(this, &HiderPlugin::HookOnClientConnectedPost), true);
+    SH_ADD_HOOK(IServerGameClients, ClientPutInServer, gameclients, SH_MEMBER(this, &HiderPlugin::HookClientPutInServerPost), true);
+    SH_ADD_HOOK(IServerGameClients, ClientDisconnect, gameclients, SH_MEMBER(this, &HiderPlugin::HookClientDisconnectPre), false);
+    SH_ADD_HOOK(IServerGameDLL, GameFrame, server, SH_MEMBER(this, &HiderPlugin::HookGameFramePost), true);
+    SH_ADD_HOOK(ICvar, DispatchConCommand, icvar, SH_MEMBER(this, &HiderPlugin::HookDispatchConCommandPre), false);
+    SH_ADD_HOOK(ICvar, DispatchConCommand, icvar, SH_MEMBER(this, &HiderPlugin::HookDispatchConCommandPost), true);
 
     int installedHooks = 0;
     if (identity_hooks::MaintainQuotaTarget()) ++installedHooks;
@@ -352,38 +371,53 @@ bool HiderPlugin::Load(PluginId id, ISmmAPI* ismm, char* error, size_t maxlen, b
     if (identity_hooks::HandleJoinTeamTarget()) ++installedHooks;
     if (identity_hooks::HumanTeamRestrictionTarget()) ++installedHooks;
     if (identity_hooks::SameMapTeardownTarget()) ++installedHooks;
-    META_CONPRINTF("[BOTHIDER] config mode=%s fake_ping=%s range=%d-%d identities=%zu\n", IsBotMode() ? "bot" : "player",
-                   m_fakePingEnabled ? "on" : "off", m_fakePingMin, m_fakePingMax, BotInfo().Count());
+    META_CONPRINTF("[BOTHIDER] config mode=%s fake_ping=%s range=%d-%d identities=%zu\n",
+                   IsBotMode() ? "bot" : "player", m_fakePingEnabled ? "on" : "off", m_fakePingMin, m_fakePingMax,
+                   BotInfo().Count());
     META_CONPRINTF("[BOTHIDER] loaded v%s hooks=%d/5 util_remove=%s schema=%s shm=%s avatar=%s\n", GetVersion(), installedHooks,
-                   entity_access::UtilRemoveTarget() ? "ok" : "fail", schemaReady ? "ok" : "fail", sharedMemoryReady ? "ok" : "fail",
-                   networkStringTables ? "ok" : "fail");
+                   entity_access::UtilRemoveTarget() ? "ok" : "fail", schemaReady ? "ok" : "fail",
+                   sharedMemoryReady ? "ok" : "fail", networkStringTables ? "ok" : "fail");
+    SetLifecycleActive();
     return true;
 }
 
 // Removes hooks and releases every plugin module
 bool HiderPlugin::Unload(char* error, size_t maxlen)
 {
-    if (!identity_hooks::Remove())
+    const bool restoreOwner = BeginLifecycleTeardown();
+    int restoredClients = 0;
+    if (restoreOwner)
     {
-        std::snprintf(error, maxlen, "failed to uninstall funchook detours");
-        return false;
+        restoredClients = identity_runtime::RestoreManagedClientsForEngineTeardown();
+        EndLifecycleTeardown();
     }
-    SH_REMOVE_HOOK(IServerGameClients, OnClientConnected, g_gameclients, SH_MEMBER(this, &HiderPlugin::HookOnClientConnectedPost), true);
-    SH_REMOVE_HOOK(IServerGameClients, ClientPutInServer, g_gameclients, SH_MEMBER(this, &HiderPlugin::HookClientPutInServerPost), true);
-    SH_REMOVE_HOOK(IServerGameClients, ClientDisconnect, g_gameclients, SH_MEMBER(this, &HiderPlugin::HookClientDisconnectPre), false);
-    SH_REMOVE_HOOK(IServerGameDLL, GameFrame, g_server, SH_MEMBER(this, &HiderPlugin::HookGameFramePost), true);
-    SH_REMOVE_HOOK(ICvar, DispatchConCommand, g_icvar, SH_MEMBER(this, &HiderPlugin::HookDispatchConCommandPre), false);
-    SH_REMOVE_HOOK(ICvar, DispatchConCommand, g_icvar, SH_MEMBER(this, &HiderPlugin::HookDispatchConCommandPost), true);
+    SH_REMOVE_HOOK(IServerGameClients, OnClientConnected, gameclients, SH_MEMBER(this, &HiderPlugin::HookOnClientConnectedPost), true);
+    SH_REMOVE_HOOK(IServerGameClients, ClientPutInServer, gameclients, SH_MEMBER(this, &HiderPlugin::HookClientPutInServerPost), true);
+    SH_REMOVE_HOOK(IServerGameClients, ClientDisconnect, gameclients, SH_MEMBER(this, &HiderPlugin::HookClientDisconnectPre), false);
+    SH_REMOVE_HOOK(IServerGameDLL, GameFrame, server, SH_MEMBER(this, &HiderPlugin::HookGameFramePost), true);
+    SH_REMOVE_HOOK(ICvar, DispatchConCommand, icvar, SH_MEMBER(this, &HiderPlugin::HookDispatchConCommandPre), false);
+    SH_REMOVE_HOOK(ICvar, DispatchConCommand, icvar, SH_MEMBER(this, &HiderPlugin::HookDispatchConCommandPost), true);
 
     if (m_startChangeLevelHookId != 0)
     {
         SH_REMOVE_HOOK_ID(m_startChangeLevelHookId);
         m_startChangeLevelHookId = 0;
     }
+
+    // SourceHook callbacks are quiesced before removing native trampolines.
+    // Native detours remain installed until identity_hooks::Remove() waits for
+    // any engine thread already inside a detour.
+    if (!identity_hooks::Remove())
+    {
+        std::snprintf(error, maxlen, "failed to uninstall funchook detours");
+        return false;
+    }
+
     m_hookedGameServer = nullptr;
+    META_CONPRINTF("[BOTHIDER] Unload restored=%d\n", restoredClients);
     identity_state::ClearAll();
     Manager().ReleaseAll();
-    avatar::ProcessOverrides();
+    identity_runtime::ClearPendingControllerRemovals();
     avatar::ResetRuntime();
     Publisher().Shutdown();
     avatar::SetStringTableContainer(nullptr);

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -8,7 +8,10 @@
 #include <playerslot.h>
 #include <tier1/utlvector.h>
 #include <array>
+#include <atomic>
+#include <condition_variable>
 #include <cstdint>
+#include <mutex>
 
 class CServerSideClient;
 class INetworkGameClient;
@@ -38,39 +41,66 @@ class HiderPlugin : public ISmmPlugin, public IMetamodListener
     const char* GetDescription() override { return "Bot persona/steamid/ping/crosshair/avatar hider"; }
     const char* GetURL() override { return ""; }
     const char* GetLicense() override { return "AGPL-3.0"; }
-    const char* GetVersion() override { return "0.4.1"; }
+    const char* GetVersion() override { return "0.4.0"; }
     const char* GetDate() override { return __DATE__; }
     const char* GetLogTag() override { return "BH"; }
 
     // IMetamodListener
-    void OnLevelInit(char const* mapName, char const*, char const*, char const*, bool, bool) override;
+    void OnLevelInit(char const* pMapName, char const*, char const*, char const*, bool, bool) override;
     void OnLevelShutdown() override;
 
     // Hook entry points
-    void
-    HookOnClientConnectedPost(CPlayerSlot slot, const char* name, uint64 xuid, const char* networkId, const char* address, bool fakePlayer);
-    void HookClientPutInServerPost(CPlayerSlot slot, char const* name, int type, uint64 xuid);
-    void
-    HookClientDisconnectPre(CPlayerSlot slot, ENetworkDisconnectionReason reason, const char* name, uint64 xuid, const char* networkId);
+    void HookOnClientConnectedPost(
+        CPlayerSlot slot, const char* pszName, uint64 xuid, const char* pszNetworkID, const char* pszAddress, bool bFakePlayer);
+    void HookClientPutInServerPost(CPlayerSlot slot, char const* pszName, int type, uint64 xuid);
+    void HookClientDisconnectPre(
+        CPlayerSlot slot, ENetworkDisconnectionReason reason, const char* pszName, uint64 xuid, const char* pszNetworkID);
     CUtlVector<INetworkGameClient*>* HookStartChangeLevelPre(const char* mapName, const char* landmark, void* changelevelState);
-    void HookGameFramePost(bool simulating, bool firstTick, bool lastTick);
+    void HookGameFramePost(bool simulating, bool bFirstTick, bool bLastTick);
 
     // ICvar::DispatchConCommand — wrap Valve population commands in one identity transaction
-    void HookDispatchConCommandPre(ConCommandRef command, const CCommandContext&, const CCommand& arguments);
-    void HookDispatchConCommandPost(ConCommandRef command, const CCommandContext&, const CCommand& arguments);
+    void HookDispatchConCommandPre(ConCommandRef cmd, const CCommandContext& ctx, const CCommand& args);
+    void HookDispatchConCommandPost(ConCommandRef cmd, const CCommandContext& ctx, const CCommand& args);
 
     // Changes the global managed-bot identity mode
     void SetIdentityMode(IdentityMode mode);
     bool IsDisguiseEnabled() const { return m_identityMode == IdentityMode::Player; }
     bool IsBotMode() const { return m_identityMode == IdentityMode::Bot; }
 
+    // Native identity hooks must not touch level-owned objects while the engine
+    // is shutting down or changing maps.
+    void SetLifecycleActive();
+    // Claims the one teardown restore window. Callers that lose the claim wait
+    // for the restore to finish and must not touch level-owned entities.
+    bool BeginLifecycleTeardown();
+    void EndLifecycleTeardown();
+    bool IsLifecycleActive() const
+    {
+        return m_LifecycleState.load(std::memory_order_acquire) == LifecycleState::Active;
+    }
+    bool IsLifecycleRestorationActive() const
+    {
+        return m_TeardownRestoreActive.load(std::memory_order_acquire);
+    }
+
     // Toggle the display-name source: true=bot_info.json name, false=botprofile name
     void SetUseBotInfoName(bool useBotInfo) { m_useBotInfoName = useBotInfo; }
 
   private:
+    enum class LifecycleState : uint8_t
+    {
+        Inactive,
+        Active,
+        Teardown,
+    };
+
     void* m_hookedGameServer = nullptr;
     int m_startChangeLevelHookId = 0;
     bool m_selfDisabled = false;
+    std::atomic<LifecycleState> m_LifecycleState{LifecycleState::Inactive};
+    std::atomic_bool m_TeardownRestoreActive{false};
+    mutable std::mutex m_LifecycleMutex;
+    std::condition_variable m_LifecycleCv;
     unsigned int m_tickCounter = 0; // throttles per-tick idle-timer reset
     IdentityMode m_identityMode = IdentityMode::Player;
     bool m_fakePingEnabled = true;


### PR DESCRIPTION
## Problem

During level shutdown or map transitions, BotHider could access client/controller objects while the engine was already dismantling them. Concurrent shutdown callbacks could also attempt restoration more than once, leading to native crashes in engine modules.

## Fix

- Add an atomic `Inactive -> Active -> Teardown` lifecycle gate around native and managed callbacks.
- Serialize teardown restoration so only one callback accesses level-owned entities.
- Restore managed clients only through a restricted pre-teardown window.
- Stop resolver, identity, userinfo, deferred removal, GameFrame, and avatar writes once teardown begins.
- Validate controller class, deletion state, and entity handles before controller flag writes.
- Discard in-progress population snapshots during teardown.
- Track in-flight funchook detours and wait for them during unload; remove SourceHook callbacks before destroying native trampolines.
- Keep the same-map collector hook disabled until its entity lifetime contract is safe to re-enable.

## Validation

- `cmake --build build-local -j2` passed.
- `dotnet build csharp/BotHiderImpl/BotHiderImpl.csproj -c Release --no-restore` passed with 0 warnings and 0 errors.
- `git diff --check` passed.
- The previously reported post-intermission/no-vote crash was not reproduced with the earlier lifecycle mitigation.
- **Need more test:** the new serialized restoration path requires maintainer review and runtime shutdown/map-transition testing on the supported server builds.