### PR TITLE
fix: preserve native_bot identity mode configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 2. Extract the archive and copy the `/addons/` folder into your server's `/game/csgo/` directory.
 3. Restart the server.
 
-The packaged `addons/BotHider/config.json` selects the identity mode and fake-ping behavior. Use `"player"` to keep BotHider's synthetic-player presentation, or use `"bot"` to retain Valve's native bot flags. Fake-ping values are constrained to the configured inclusive range. Missing settings use the packaged defaults.
+The packaged `addons/BotHider/config.json` selects the identity mode and fake-ping behavior. Use `"player"` to keep BotHider's synthetic-player presentation, or use `"native_bot"` to retain Valve's native bot flags. The previously published `"bot"` value remains accepted as a compatibility alias for `"native_bot"`. Fake-ping values are constrained to the configured inclusive range. Missing settings use the packaged defaults.
 
 ------------------------------------------------------------------------
 
@@ -38,7 +38,7 @@ The packaged `addons/BotHider/config.json` selects the identity mode and fake-pi
 | `bh_setsid <slot> <SteamID64>` | Change a bot's SteamID |
 | `bh_setflair <slot> <item_def_index>` | Change a bot's scoreboard flair (`0` clears it) |
 | `bh_setavatar <slot> <png_path/0>` | Apply a server-local PNG avatar, or use `0` to clear it (`@css/root` or server console/RCON) |
-| `bh_identity_mode <player/bot>` | Change the managed-bot identity mode |
+| `bh_identity_mode <player/native_bot>` | Change the managed-bot identity mode (`bot` is accepted as a compatibility alias) |
 | `bh_namesource <0/1>` | **0** = use name from `botprofile.db` (default)<br>**1** = use name from `bot_info.json` (only affects new bots) |
 
 ------------------------------------------------------------------------

--- a/TECH.md
+++ b/TECH.md
@@ -103,7 +103,7 @@ Located in `/game/csgo/addons/BotHider/config.json`:
 }
 ```
 
-`player` is the default and enables the synthetic-player presentation. `bot` leaves the client/controller fake flags under Valve's native BotManager while BotHider continues to manage names, SteamIDs, and custom avatar presentation. `fake_ping.enabled` controls ping generation, and `min`/`max` are inclusive bounds for the final displayed value. The configuration is read when the Metamod plugin loads.
+`player` is the default and enables the synthetic-player presentation. `native_bot` leaves the client/controller fake flags under Valve's native BotManager while BotHider continues to manage names, SteamIDs, and custom avatar presentation. The `bot` value introduced by PR #26 remains accepted as a compatibility alias and has identical behavior. This alias exists because PR #26 changed the parser value without updating the published configuration contract; existing `native_bot` configurations must continue to work. `fake_ping.enabled` controls ping generation, and `min`/`max` are inclusive bounds for the final displayed value. The configuration is read when the Metamod plugin loads.
 
 ------------------------------------------------------------------------
 
@@ -137,7 +137,7 @@ public interface IBotHiderApi
     bool     SetScoreboardFlair(int slot, uint itemDefIndex);
 
     // --- global toggles ---
-    bool     SetIdentityMode(BotIdentityMode mode);
+    bool     SetIdentityMode(BotIdentityMode mode); // Bot corresponds to config value native_bot
     bool     SetNameSource(bool useBotInfo); // true=bot_info name, false=botprofile name
 }
 ```

--- a/csharp/BotHiderImpl/BotHiderImplPlugin.cs
+++ b/csharp/BotHiderImpl/BotHiderImplPlugin.cs
@@ -574,31 +574,32 @@ public class BotHiderImplPlugin : BasePlugin
             : $"[BotHider] avatar rejected slot={slot}: {error}");
     }
 
-    // bh_identity_mode <player|bot> - changes the managed-bot identity mode
-    [ConsoleCommand("bh_identity_mode", "Set identity mode: bh_identity_mode <player|bot>")]
+    // bh_identity_mode <player|native_bot> - changes the managed-bot identity mode
+    [ConsoleCommand("bh_identity_mode", "Set identity mode: bh_identity_mode <player|native_bot>")]
     public void OnIdentityMode(CCSPlayerController? player, CommandInfo cmd)
     {
         if (_client == null) { cmd.ReplyToCommand("[BotHider] not initialized"); return; }
         BotIdentityMode mode;
         if (cmd.ArgCount < 2)
         {
-            cmd.ReplyToCommand("usage: bh_identity_mode <player|bot>");
+            cmd.ReplyToCommand("usage: bh_identity_mode <player|native_bot>");
             return;
         }
 
         string value = cmd.GetArg(1);
         if (value.Equals("player", StringComparison.OrdinalIgnoreCase))
             mode = BotIdentityMode.Player;
-        else if (value.Equals("bot", StringComparison.OrdinalIgnoreCase))
+        else if (value.Equals("native_bot", StringComparison.OrdinalIgnoreCase) ||
+                 value.Equals("bot", StringComparison.OrdinalIgnoreCase))
             mode = BotIdentityMode.Bot;
         else
         {
-            cmd.ReplyToCommand("usage: bh_identity_mode <player|bot>");
+            cmd.ReplyToCommand("usage: bh_identity_mode <player|native_bot>");
             return;
         }
 
         bool ok = _client.SetIdentityMode(mode);
-        cmd.ReplyToCommand($"[BotHider] identity mode -> {mode.ToString().ToLowerInvariant()} ({ok})");
+        cmd.ReplyToCommand($"[BotHider] identity mode -> {(mode == BotIdentityMode.Bot ? "native_bot" : "player")} ({ok})");
     }
 
     // bh_namesource <0|1> — 0=botprofile name (default), 1=bot_info.json name

--- a/src/BotIdentity/command_hooks.cpp
+++ b/src/BotIdentity/command_hooks.cpp
@@ -123,7 +123,7 @@ void HiderPlugin::SetIdentityMode(IdentityMode mode)
     if (m_IdentityMode == mode) return;
     m_IdentityMode = mode;
     identity_runtime::ApplyManagedDisguise(mode == IdentityMode::Player);
-    META_CONPRINTF("[BOTHIDER] identity mode=%s\n", mode == IdentityMode::Bot ? "bot" : "player");
+    META_CONPRINTF("[BOTHIDER] identity mode=%s\n", mode == IdentityMode::Bot ? "native_bot" : "player");
 }
 
 // Restores native bot identity and clears managed state before a level transition

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -137,7 +137,14 @@ bool HiderPlugin::Load(PluginId id, ISmmAPI* ismm, char* error, size_t maxlen, b
                 if (config.contains("identity_mode") && config["identity_mode"].is_string())
                 {
                     const std::string mode = config["identity_mode"].get<std::string>();
-                    if (mode == "bot") m_IdentityMode = IdentityMode::Bot;
+                    if (mode == "native_bot" || mode == "bot")
+                    {
+                        m_IdentityMode = IdentityMode::Bot;
+                        if (mode == "bot")
+                        {
+                            META_CONPRINTF("[BOTHIDER] identity_mode='bot' is a compatibility alias for 'native_bot'\n");
+                        }
+                    }
                     else if (mode != "player")
                         META_CONPRINTF("[BOTHIDER] warning: unsupported identity_mode='%s'; using player\n", mode.c_str());
                 }


### PR DESCRIPTION
## Summary

- Restore `identity_mode: "native_bot"` as a supported configuration value.
- Keep the previously published `"bot"` value as a compatibility alias with identical behavior.
- Accept both names in `bh_identity_mode` and report the canonical `native_bot` name.
- Document the PR #26 naming mismatch and why native bot identity is required for population/vote integrations.

## Why

PR #26 changed the parser from `native_bot` to `bot`, while the published PR description and existing configurations still used `native_bot`. The old value then fell through to player mode, which can make Valve and population-management plugins count managed bots as humans. This change preserves both configuration forms without changing the internal C# enum/API or the default player mode.

## Validation

- `dotnet build csharp/BotHiderApi/BotHiderApi.csproj -c Release --no-restore`
- `dotnet build csharp/BotHiderImpl/BotHiderImpl.csproj -c Release --no-restore`
- Linux CMake build with HL2SDKCS2, MMSOURCE_DEV, CSGO_PROTO, and protoc 3.21.12
- `git diff --check`
