### PR TITLE
[Need more test] fix: skip population identity transactions in bot mode

### DIFF
--- a/src/BotIdentity/command_hooks.cpp
+++ b/src/BotIdentity/command_hooks.cpp
@@ -64,8 +64,14 @@ void HiderPlugin::Hook_DispatchConCommand_Pre(ConCommandRef command, const CComm
 
     if (IsBotAddCommand(commandName))
     {
-        identity_hooks::BeginPopulationTransaction(IsDisguiseEnabled());
-        ++m_PopulationCommandDepth;
+        // Native Bot mode leaves Valve's population state authoritative. The
+        // transaction is only needed while player mode temporarily restores
+        // fake-client identity around the command.
+        if (IsDisguiseEnabled())
+        {
+            identity_hooks::BeginPopulationTransaction(true);
+            ++m_PopulationCommandDepth;
+        }
         RETURN_META(MRES_IGNORED);
     }
 
@@ -87,8 +93,11 @@ void HiderPlugin::Hook_DispatchConCommand_Pre(ConCommandRef command, const CComm
 
     if (!IsKickCommand(commandName)) RETURN_META(MRES_IGNORED);
 
-    identity_hooks::BeginPopulationTransaction(IsDisguiseEnabled());
-    ++m_PopulationCommandDepth;
+    if (IsDisguiseEnabled())
+    {
+        identity_hooks::BeginPopulationTransaction(true);
+        ++m_PopulationCommandDepth;
+    }
     RETURN_META(MRES_IGNORED);
 }
 

--- a/src/BotIdentity/identity_hooks.cpp
+++ b/src/BotIdentity/identity_hooks.cpp
@@ -362,25 +362,32 @@ static void ClearBindings()
 // Restores Bot identity while the engine counts bot quota
 static int64_t CS2BH_FASTCALL Detour_MaintainBotQuota(void* manager)
 {
-    PopulationTransactionScope scope(g_Plugin.IsDisguiseEnabled());
+    if (!g_Plugin.IsDisguiseEnabled())
+        return g_pfnQuotaTramp ? g_pfnQuotaTramp(manager) : 0;
+    PopulationTransactionScope scope(true);
     return g_pfnQuotaTramp ? g_pfnQuotaTramp(manager) : 0;
 }
 
 // Restores Bot identity while the engine applies mp_humanteam
 static int64_t CS2BH_FASTCALL Detour_ApplyHumanTeamRestriction()
 {
-    PopulationTransactionScope scope(g_Plugin.IsDisguiseEnabled());
+    if (!g_Plugin.IsDisguiseEnabled())
+        return g_pfnApplyHumanTeamRestrictionTramp ? g_pfnApplyHumanTeamRestrictionTramp() : 0;
+    PopulationTransactionScope scope(true);
     return g_pfnApplyHumanTeamRestrictionTramp ? g_pfnApplyHumanTeamRestrictionTramp() : 0;
 }
 
 // Restores Bot identity only while the engine validates an initial team join
 static int64_t CS2BH_FASTCALL Detour_HandleCommandJoinTeam(void* controller, unsigned int requestedTeam, bool unknownFlag)
 {
+    if (!g_Plugin.IsDisguiseEnabled())
+        return g_pfnHandleJoinTeamTramp ? g_pfnHandleJoinTeamTramp(controller, requestedTeam, unknownFlag) : 0;
+
     ManagedControllerTrace trace = TraceManagedController(controller);
     std::unique_ptr<PopulationTransactionScope> populationScope;
     if (trace.Managed && !trace.Hltv)
     {
-        populationScope = std::make_unique<PopulationTransactionScope>(g_Plugin.IsDisguiseEnabled());
+        populationScope = std::make_unique<PopulationTransactionScope>(true);
     }
 
     return g_pfnHandleJoinTeamTramp ? g_pfnHandleJoinTeamTramp(controller, requestedTeam, unknownFlag) : 0;


### PR DESCRIPTION
## Need more test

This PR prevents unnecessary BotHider identity transactions when `identity_mode=bot` is active. Valve retains full control of native bot population and team-management operations.

## Change

- Skip population transactions around `bot_add`/`bot_kick` commands in native bot mode.
- Bypass the `MaintainBotQuota`, human-team restriction, and managed join-team identity transactions in native bot mode.
- Keep `identity_mode=player` behavior unchanged.

## Rationale

Native bot mode already exposes Valve's authoritative fake-client identity. Snapshotting and rewriting those clients is unnecessary and can touch a controller while it is being created, rejected, or destroyed. Avoiding these writes narrows BotHider's interaction with engine-owned population state.

## Validation

- Linux CMake build passed.
- BotHiderImpl/BotHiderApi Release build passed with 0 warnings and 0 errors.
- `git diff --check` passed.
- Runtime validation is still required.

## Required review/test

Please test native bot population operations with `identity_mode=bot`, including successful and rejected bot creation, bot removal, team changes, map transitions, and repeated population updates. Confirm that names, SteamIDs, avatars, fake ping, `IsBot` compatibility, team restrictions, quota maintenance, and teardown behavior remain correct.

Potential behavior impact is intentionally unverified: native bot mode no longer receives BotHider's temporary identity restoration around population/team calls. The change is intended to preserve native engine behavior, but requires additional server-side review before merge.
